### PR TITLE
fix(pwa): Service Worker Blocker fixes (B-01, B-02)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,27 +3,13 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import ModernApp from './ModernApp.tsx'
 
-// Service Worker登録（開発中は無効化）
-if ('serviceWorker' in navigator && import.meta.env.PROD) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
-      .then((registration) => {
-        if (import.meta.env.DEV) {
-          console.log('[Dev] SW registered: ', registration);
-        }
-      })
-      .catch((registrationError) => {
-        console.error('SW registration failed: ', registrationError);
-      });
-  });
-} else if ('serviceWorker' in navigator) {
-  // 開発モード: 既存のService Workerを全て解除
+// 開発モード: 既存のService Workerを全て解除
+// 本番環境のService Worker登録は usePWA フックに一元化
+if ('serviceWorker' in navigator && import.meta.env.DEV) {
   navigator.serviceWorker.getRegistrations().then((registrations) => {
     registrations.forEach((registration) => {
       registration.unregister();
-      if (import.meta.env.DEV) {
-        console.log('[Dev] Service Worker unregistered for development');
-      }
+      console.log('[Dev] Service Worker unregistered for development');
     });
   });
 }


### PR DESCRIPTION
## Summary
Issue #10のBlocker修正（B-01, B-02）を実装しました。

## Changes

### B-01: Service Worker重複登録を解消
**Problem**: `main.tsx` と `usePWA.ts` で重複登録が発生
**Solution**:
- `main.tsx` から本番環境のSW登録を削除
- `usePWA` フックに登録を一元化
- 開発環境のSW解除処理は維持

**Modified**: `src/main.tsx` (lines 6-18 → lines 6-15)

### B-02: キャッシュ有効期限ロジックを実装
**Problem**: キャッシュ有効期限の定義はあるが、実際のチェックロジックが未実装
**Solution**:
- `cacheWithExpiration()` 関数: タイムスタンプ付きでキャッシュに保存
- `checkCacheExpiration()` 関数: 有効期限をチェック
- `cacheFirstStrategy()` 更新: 期限チェック & 期限切れ削除
- `networkFirstStrategy()` 更新: オフライン時のUX配慮（期限切れでもキャッシュを返す）
- 後方互換性を確保: タイムスタンプなしキャッシュは有効とみなす

**Modified**: `public/sw.js` (+67 lines)
- `cacheWithExpiration()` (lines 341-354)
- `checkCacheExpiration()` (lines 359-371)
- `cacheFirstStrategy()` 更新 (lines 194-206)
- `networkFirstStrategy()` 更新 (lines 267-279)

## Tech-Lead Review
⭐⭐⭐⭐☆ (4/5)
- **Blocker問題**: なし
- **後方互換性**: ✅ 配慮済み
- **UX優先設計**: ✅ オフライン時は期限切れでもキャッシュを返す
- **Major指摘**: テストコード未作成 → Issue #31で追跡

## Test Results
- ビルド: ✅ 成功
- 既存テスト: ✅ 735 passing (修正による影響なし)

## Pending Tasks (別Issueで対応)
- [ ] M-01: Service Workerテストコード作成 (Issue #31)
- [ ] N-01: キャッシュ戦略のドキュメント化
- [ ] N-02: エラーログ改善

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)