### PR TITLE
fix(test): resolve linter warnings in setupTests

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -236,11 +236,11 @@ if (typeof HTMLCanvasElement !== 'undefined') {
           width,
           height,
         })),
-        getImageData: vi?.fn((sx: number, sy: number, sw: number, sh: number) => ({
+        getImageData: vi?.fn((_sx: number, _sy: number, sw: number, sh: number) => ({
           data: new Uint8ClampedArray(sw * sh * 4),
           width: sw,
           height: sh,
-        })) || ((sx: number, sy: number, sw: number, sh: number) => ({
+        })) || ((_sx: number, _sy: number, sw: number, sh: number) => ({
           data: new Uint8ClampedArray(sw * sh * 4),
           width: sw,
           height: sh,
@@ -258,11 +258,11 @@ if (typeof HTMLCanvasElement !== 'undefined') {
     return null;
   };
 
-  HTMLCanvasElement.prototype.toDataURL = function(type?: string, quality?: number) {
+  HTMLCanvasElement.prototype.toDataURL = function(_type?: string, _quality?: number) {
     return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
   };
 
-  HTMLCanvasElement.prototype.toBlob = function(callback: BlobCallback, type?: string, quality?: number) {
+  HTMLCanvasElement.prototype.toBlob = function(callback: BlobCallback, type?: string, _quality?: number) {
     setTimeout(() => {
       callback(new Blob([''], { type: type || 'image/png' }));
     }, 0);


### PR DESCRIPTION
## Summary

- Add underscore prefix to unused parameters in setupTests.ts
- Resolve ESLint warnings for unused function parameters

## Changes

- Updated `getImageData`, `toDataURL`, and `toBlob` mock functions
- All unused parameters now prefixed with `_` to comply with ESLint rules

## Test plan

- [x] Run `npm run test:fast`
- [x] Verify no linter warnings
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)