### PR TITLE
test(ci): use vi.useFakeTimers for stable ViewportDetector test (#123)

### DIFF
--- a/src/utils/responsive/__tests__/ViewportDetector.test.ts
+++ b/src/utils/responsive/__tests__/ViewportDetector.test.ts
@@ -139,6 +139,14 @@ describe('ViewportDetector', () => {
   });
 
   describe('viewport change detection', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     test('should call callback on viewport change', async () => {
       const callback = vi.fn();
       const unsubscribe = detector.onViewportChange(callback);
@@ -150,8 +158,8 @@ describe('ViewportDetector', () => {
       mockWindowSize(768, 1024);
       fireResizeEvent();
 
-      // リサイズイベントのデバウンス待機
-      await new Promise(resolve => setTimeout(resolve, 150));
+      // リサイズイベントのデバウンス待機（100ms）
+      await vi.advanceTimersByTimeAsync(100);
 
       // Then: コールバックが呼ばれる
       expect(callback).toHaveBeenCalledWith({
@@ -174,8 +182,8 @@ describe('ViewportDetector', () => {
       mockWindowSize(1920, 1080);
       fireResizeEvent();
 
-      // デバウンス待機
-      await new Promise(resolve => setTimeout(resolve, 150));
+      // デバウンス待機（100ms）
+      await vi.advanceTimersByTimeAsync(100);
 
       expect(callback).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## 概要

ViewportDetectorのテスト "should call callback on viewport change" がCI環境で失敗する問題を修正しました。

Closes #123

## 変更内容

### 修正箇所
- `src/utils/responsive/__tests__/ViewportDetector.test.ts`

### 実装内容

1. **vi.useFakeTimers() の導入**
   - `beforeEach` でフェイクタイマーを有効化
   - `afterEach` でリアルタイマーに戻す
   - テスト失敗時でもクリーンアップが確実に実行される

2. **デバウンス待機方法の変更**
   - Before: `await new Promise(resolve => setTimeout(resolve, 150))`
   - After: `await vi.advanceTimersByTimeAsync(100)`
   - デバウンス時間（100ms）を正確に制御

### 影響範囲

- 2つのテストケース
  - "should call callback on viewport change"
  - "should not call callback after unsubscribe"

## 問題の原因

CI環境（GitHub Actions）では、実際の `setTimeout` を使用した待機が不安定：
- イベントループの遅延
- jsdomでのタイマー処理の不確実性
- テスト並列実行時のリソース競合

これにより、100msのデバウンス処理が150ms待機しても間に合わないケースが発生していました。

## 解決アプローチ

`vi.useFakeTimers()` を使用することで：
- タイマーを完全に制御可能
- CI環境の負荷に影響されない
- テスト実行時間の短縮
- より正確なデバウンス処理のテスト

## テスト結果

### ローカル環境
```
✓ |unit| src/utils/responsive/__tests__/ViewportDetector.test.ts  (16 tests) 16ms
```

### CI環境
- GitHub Actionsでの確認待ち

## レビュー

- ✅ qa-engineer エージェントレビュー完了（評価: 4/5）
- ✅ Medium指摘事項の修正完了（beforeEach/afterEachでのタイマー管理）

## チェックリスト

- [x] ローカル環境でテストが通過する
- [x] qa-engineerエージェントのレビュー完了
- [x] レビュー指摘事項を修正
- [x] コミットメッセージがConventional Commits準拠
- [ ] CI環境でテストが通過する（PR作成後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)