### PR TITLE
hotfix: remove duplicate TIDE_TOOLTIP definition in testIds.ts

### DIFF
--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -93,7 +93,6 @@ export const TestIds = {
 
   // Generic
   FLOATING_ACTION_BUTTON: 'floating-action-button',
-  TIDE_TOOLTIP: 'tide-tooltip',
   TIDE_GRAPH_SKELETON: 'tide-graph-skeleton',
   TIDE_GRAPH_ERROR: 'tide-graph-error',
   TIDE_GRAPH_CONTAINER: 'tide-graph-container',


### PR DESCRIPTION
## 🚨 Critical Hotfix

### 問題
PR #164マージ後、mainブランチでビルドエラーが発生しVercelデプロイメントが失敗している状態です。

### 原因
`src/constants/testIds.ts` で `TIDE_TOOLTIP` が2箇所で定義されていました:
- Line 55: TideChart Accessibility section (正)
- Line 96: Generic section (重複)

### エラー
```
src/constants/testIds.ts(96,3): error TS1117: An object literal cannot have multiple properties with the same name.
```

### 修正内容
Line 96の重複定義を削除しました。

### 影響
- ✅ TypeScript compilation error 解決
- ✅ Vercel deployment 復旧
- ✅ Build成功確認済み

### テスト
```bash
npm run build
# ✓ built in 6.50s
```

---

🚨 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>