### PR TITLE
hotfix: remove unused bottom navigation tide tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { DeleteConfirmModal } from './components/DeleteConfirmModal'
 import { PWAInstallPrompt } from './components/PWAInstallPrompt'
 import { PWAInstallBanner } from './components/PWAInstallBanner'
 import { PWAUpdateNotification } from './components/PWAUpdateNotification'
-import { TideChart } from './components/chart/tide/TideChart'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ErrorDisplay } from './components/errors'
 import { ToastContainer } from './components/ToastContainer'
@@ -33,7 +32,7 @@ function App() {
   const [dbMessage, setDbMessage] = useState<string>('')
   const [storeStatus, setStoreStatus] = useState<'loading' | 'success' | 'error'>('loading')
   const [storeMessage, setStoreMessage] = useState<string>('')
-  const [activeTab, setActiveTab] = useState<'form' | 'list' | 'tide-chart' | 'debug'>('form')
+  const [activeTab, setActiveTab] = useState<'form' | 'list' | 'debug'>('form')
   const [selectedRecord, setSelectedRecord] = useState<FishingRecord | null>(null)
   const [editingRecord, setEditingRecord] = useState<FishingRecord | null>(null)
   const [deletingRecord, setDeletingRecord] = useState<FishingRecord | null>(null)
@@ -295,14 +294,13 @@ function App() {
   }, []);
 
   // 型安全なTestIDsマッピング
-  const TAB_TEST_IDS: Record<'form' | 'list' | 'tide-chart' | 'debug', string> = {
+  const TAB_TEST_IDS: Record<'form' | 'list' | 'debug', string> = {
     form: TestIds.FORM_TAB,
     list: TestIds.FISHING_RECORDS_LINK,
-    'tide-chart': TestIds.TIDE_GRAPH_TAB,
     debug: TestIds.DEBUG_TAB,
   } as const;
 
-  const TabButton = ({ tab, label, emoji }: { tab: 'form' | 'list' | 'tide-chart' | 'debug', label: string, emoji: string }) => (
+  const TabButton = ({ tab, label, emoji }: { tab: 'form' | 'list' | 'debug', label: string, emoji: string }) => (
     <Button
       variant={activeTab === tab ? 'primary' : 'text'}
       size="md"
@@ -386,7 +384,6 @@ function App() {
         }}>
           <TabButton tab="form" label="記録登録" emoji="✏️" />
           <TabButton tab="list" label="写真で確認" emoji="📸" />
-          <TabButton tab="tide-chart" label="潮汐グラフ" emoji="🌊" />
           <TabButton tab="debug" label="デバッグ" emoji="🔧" />
         </div>
       </div>
@@ -422,28 +419,6 @@ function App() {
               onRecordEdit={handleRecordEdit}
               onRecordDelete={handleRecordDelete}
               onDataRefresh={handleDataRefresh}
-            />
-          </div>
-        )}
-
-        {activeTab === 'tide-chart' && (
-          <div>
-            <h2 style={{
-              ...textStyles.headline.medium,
-              color: colors.text.primary,
-              marginBottom: '1.5rem',
-            }}>🌊 潮汐グラフ</h2>
-            <TideChart
-              data={[
-                { time: '00:00', tide: 120 },
-                { time: '03:00', tide: 80 },
-                { time: '06:00', tide: 200 },
-                { time: '09:00', tide: 150 },
-                { time: '12:00', tide: 90 },
-                { time: '15:00', tide: 180 },
-                { time: '18:00', tide: 140 },
-                { time: '21:00', tide: 110 }
-              ]}
             />
           </div>
         )}

--- a/src/ModernApp.tsx
+++ b/src/ModernApp.tsx
@@ -161,7 +161,7 @@ const applyFilters = (records: FishingRecord[], filters: FilterState): FishingRe
 
 function ModernApp() {
   // 状態管理
-  const [activeTab, setActiveTab] = useState<'home' | 'form' | 'list' | 'map' | 'tide' | 'debug'>('home');
+  const [activeTab, setActiveTab] = useState<'home' | 'form' | 'list' | 'map' | 'debug'>('home');
   const [selectedRecord, setSelectedRecord] = useState<FishingRecord | null>(null);
   const [editingRecord, setEditingRecord] = useState<FishingRecord | null>(null);
   const [deletingRecord, setDeletingRecord] = useState<FishingRecord | null>(null);
@@ -333,13 +333,6 @@ function ModernApp() {
       testId: TestIds.MAP_TAB,
     },
     {
-      id: 'tide',
-      label: '潮汐',
-      icon: <span style={{ fontSize: '20px' }}>🌊</span>,
-      active: activeTab === 'tide',
-      testId: TestIds.TIDE_GRAPH_TAB,
-    },
-    {
       id: 'form',
       label: '新規記録',
       icon: <Icons.Add />,
@@ -361,7 +354,6 @@ function ModernApp() {
       case 'home': return '釣果記録';
       case 'list': return '記録一覧';
       case 'map': return '釣り場マップ';
-      case 'tide': return '潮汐グラフ';
       case 'form': return '新規記録';
       case 'debug': return '設定';
       default: return '釣果記録アプリ';
@@ -374,7 +366,6 @@ function ModernApp() {
       case 'home': return `${records.length}件の記録`;
       case 'list': return '写真で振り返る';
       case 'map': return `${recordsWithCoordinates}箇所の釣り場`;
-      case 'tide': return '24時間の潮位変化';
       case 'form': return '新しい釣果を記録';
       case 'debug': return 'アプリの設定';
       default: return '';
@@ -1867,98 +1858,6 @@ function ModernApp() {
     </div>
   );
 
-  // 潮汐コンテンツ
-  const TideContent = () => {
-    if (isLoading) {
-      return (
-        <div style={{ padding: '12px' }}>
-          <Skeleton width="100%" height="400px" borderRadius="12px" />
-        </div>
-      );
-    }
-
-    if (records.length === 0) {
-      return (
-        <ModernCard variant="outlined" size="lg" style={{ margin: '16px' }}>
-          <div style={{
-            textAlign: 'center',
-            padding: '32px',
-            color: colors.text.secondary,
-          }}>
-            <span style={{ fontSize: '4rem', marginBottom: '16px', display: 'block' }}>🌊</span>
-            <div style={{
-              ...textStyles.headline.small,
-              marginBottom: '8px',
-            }}>
-              釣果記録がありません
-            </div>
-            <div style={textStyles.body.medium}>
-              GPS座標付きの釣果記録を追加すると、潮汐グラフを表示できます
-            </div>
-          </div>
-        </ModernCard>
-      );
-    }
-
-    const recordsWithCoordinates = records.filter(r => r.coordinates);
-
-    if (recordsWithCoordinates.length === 0) {
-      return (
-        <ModernCard variant="outlined" size="lg" style={{ margin: '16px' }}>
-          <div style={{
-            textAlign: 'center',
-            padding: '32px',
-            color: colors.text.secondary,
-          }}>
-            <span style={{ fontSize: '4rem', marginBottom: '16px', display: 'block' }}>📍</span>
-            <div style={{
-              ...textStyles.headline.small,
-              marginBottom: '8px',
-            }}>
-              GPS座標が記録されていません
-            </div>
-            <div style={textStyles.body.medium}>
-              位置情報付きの釣果記録を追加すると、その場所の潮汐グラフを表示できます
-            </div>
-          </div>
-        </ModernCard>
-      );
-    }
-
-    return (
-      <div style={{ padding: '16px' }}>
-        <ModernCard variant="outlined" size="lg">
-          <div style={{
-            textAlign: 'center',
-            padding: '48px 32px',
-            color: colors.text.secondary,
-          }}>
-            <span style={{ fontSize: '4rem', marginBottom: '16px', display: 'block' }}>🌊</span>
-            <div style={{
-              ...textStyles.headline.small,
-              marginBottom: '8px',
-              color: colors.text.primary,
-            }}>
-              潮汐グラフ機能
-            </div>
-            <div style={{
-              ...textStyles.body.medium,
-              marginBottom: '16px',
-            }}>
-              {recordsWithCoordinates.length}件の位置情報付き記録があります
-            </div>
-            <div style={{
-              ...textStyles.body.small,
-              color: colors.text.tertiary,
-            }}>
-              潮汐グラフ表示機能は現在開発中です
-            </div>
-          </div>
-        </ModernCard>
-      </div>
-    );
-  };
-
   // メインコンテンツレンダリング
   const renderContent = () => {
     switch (activeTab) {
@@ -1966,7 +1865,6 @@ function ModernApp() {
       case 'list': return <ListContent />;
       case 'form': return <FormContent />;
       case 'map': return <MapContent />;
-      case 'tide': return <TideContent />;
       case 'debug': return <DebugContent />;
       default: return <HomeContent />;
     }

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -58,7 +58,6 @@ export const TestIds = {
   DATA_POINT: (index: number) => `data-point-${index}`, // データポイント
 
   // Tide Integration
-  TIDE_GRAPH_TAB: 'tide-graph-tab', // Navigation: Bottom tab for tide graph page
   TIDE_GRAPH_TOGGLE_BUTTON: 'tide-graph-toggle-button', // Toggle: Button to expand/collapse tide graph section
   TIDE_INTEGRATION_SECTION: 'tide-integration-section',
   TIDE_ERROR: 'tide-error',

--- a/tests/unit/session-service.test.ts
+++ b/tests/unit/session-service.test.ts
@@ -1,0 +1,288 @@
+// セッション管理サービス ユニットテスト
+// Phase 3-4: セッション管理機能実装
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionService } from '@/lib/session-service';
+
+describe('SessionService', () => {
+  let sessionService: SessionService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionService = new SessionService({
+      timeoutMs: 1000, // 1秒（テスト用）
+      heartbeatIntervalMs: 500, // 0.5秒（テスト用）
+    });
+  });
+
+  afterEach(() => {
+    sessionService.stop();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('セッションタイムアウト検出', () => {
+    it('タイムアウト時間経過後にセッションが期限切れになること', async () => {
+      sessionService.start();
+
+      // タイムアウトまで進める
+      vi.advanceTimersByTime(1001);
+
+      const isValid = await sessionService.checkSession();
+      expect(isValid).toBe(false);
+    });
+
+    it('タイムアウト時間内であればセッションが有効であること', async () => {
+      sessionService.start();
+
+      // タイムアウト前
+      vi.advanceTimersByTime(999);
+
+      const isValid = await sessionService.checkSession();
+      expect(isValid).toBe(true);
+    });
+
+    it('タイムアウト境界値（ちょうど1000ms）で期限切れにならないこと', async () => {
+      sessionService.start();
+
+      // ちょうど1000ms
+      vi.advanceTimersByTime(1000);
+
+      const isValid = await sessionService.checkSession();
+      expect(isValid).toBe(true);
+    });
+
+    it('タイムアウト境界値（1001ms）で期限切れになること', async () => {
+      sessionService.start();
+
+      // 1001ms
+      vi.advanceTimersByTime(1001);
+
+      const isValid = await sessionService.checkSession();
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe('アクティビティ監視', () => {
+    it('click イベントでアクティビティ時刻が更新されること', () => {
+      sessionService.start();
+
+      // 半分経過
+      vi.advanceTimersByTime(500);
+      const beforeElapsed = sessionService.getElapsedTime();
+
+      // clickイベント発火
+      window.dispatchEvent(new Event('click'));
+
+      // アクティビティがリセットされているはず
+      const afterElapsed = sessionService.getElapsedTime();
+      expect(afterElapsed).toBeLessThan(beforeElapsed);
+    });
+
+    it('keydown イベントでアクティビティ時刻が更新されること', () => {
+      sessionService.start();
+
+      vi.advanceTimersByTime(500);
+      window.dispatchEvent(new Event('keydown'));
+
+      const elapsed = sessionService.getElapsedTime();
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('scroll イベントでアクティビティ時刻が更新されること', () => {
+      sessionService.start();
+
+      vi.advanceTimersByTime(500);
+      window.dispatchEvent(new Event('scroll'));
+
+      const elapsed = sessionService.getElapsedTime();
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('touchstart イベントでアクティビティ時刻が更新されること', () => {
+      sessionService.start();
+
+      vi.advanceTimersByTime(500);
+      window.dispatchEvent(new Event('touchstart'));
+
+      const elapsed = sessionService.getElapsedTime();
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('アクティビティ更新後にタイムアウトがリセットされること', async () => {
+      sessionService.start();
+
+      // 半分経過
+      vi.advanceTimersByTime(500);
+
+      // アクティビティ発生
+      window.dispatchEvent(new Event('click'));
+
+      // さらに経過（合計1001ms以上だが、リセット後は500msなので有効）
+      vi.advanceTimersByTime(501);
+
+      const isValid = await sessionService.checkSession();
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('Heartbeat検出', () => {
+    it('Heartbeat間隔でセッション有効性がチェックされること', async () => {
+      const eventSpy = vi.fn();
+      window.addEventListener('session_expired', eventSpy);
+
+      sessionService.start();
+
+      // タイムアウト経過
+      vi.advanceTimersByTime(1001);
+
+      // Heartbeat発火（500ms間隔）
+      vi.advanceTimersByTime(500);
+
+      // セッション期限切れイベントが発火しているはず
+      expect(eventSpy).toHaveBeenCalled();
+
+      window.removeEventListener('session_expired', eventSpy);
+    });
+
+    it('Heartbeat前にセッションが有効な場合はイベントが発火しないこと', () => {
+      const eventSpy = vi.fn();
+      window.addEventListener('session_expired', eventSpy);
+
+      sessionService.start();
+
+      // タイムアウト前
+      vi.advanceTimersByTime(500);
+
+      // Heartbeat発火
+      vi.advanceTimersByTime(500);
+
+      // イベントは発火していないはず
+      expect(eventSpy).not.toHaveBeenCalled();
+
+      window.removeEventListener('session_expired', eventSpy);
+    });
+  });
+
+  describe('セッション状態取得', () => {
+    it('アクティブ状態の場合は status: "active" を返すこと', () => {
+      sessionService.start();
+
+      const state = sessionService.getSessionState();
+
+      expect(state.status).toBe('active');
+      expect(state.lastActivityAt).toBeGreaterThan(0);
+      expect(state.timeoutDuration).toBe(1000);
+    });
+
+    it('期限切れ状態の場合は status: "expired" を返すこと', () => {
+      sessionService.start();
+
+      // タイムアウト経過
+      vi.advanceTimersByTime(1001);
+
+      const state = sessionService.getSessionState();
+
+      expect(state.status).toBe('expired');
+    });
+
+    it('残り時間が正しく計算されること', () => {
+      sessionService.start();
+
+      // 500ms経過
+      vi.advanceTimersByTime(500);
+
+      const remaining = sessionService.getRemainingTime();
+
+      // 1000ms - 500ms = 500ms
+      expect(remaining).toBe(500);
+    });
+
+    it('タイムアウト後の残り時間は0であること', () => {
+      sessionService.start();
+
+      // タイムアウト経過
+      vi.advanceTimersByTime(1001);
+
+      const remaining = sessionService.getRemainingTime();
+
+      expect(remaining).toBe(0);
+    });
+  });
+
+  describe('セッション管理の開始・停止', () => {
+    it('start() でアクティビティ監視が開始されること', () => {
+      sessionService.start();
+
+      // clickイベントでアクティビティが更新されることを確認
+      vi.advanceTimersByTime(100);
+      window.dispatchEvent(new Event('click'));
+
+      const elapsed = sessionService.getElapsedTime();
+      expect(elapsed).toBeLessThan(100);
+    });
+
+    it('stop() でアクティビティ監視が停止されること', () => {
+      sessionService.start();
+      sessionService.stop();
+
+      // clickイベントを発火してもアクティビティが更新されないことを確認
+      vi.advanceTimersByTime(100);
+      const beforeElapsed = sessionService.getElapsedTime();
+
+      window.dispatchEvent(new Event('click'));
+
+      const afterElapsed = sessionService.getElapsedTime();
+      expect(afterElapsed).toBeGreaterThanOrEqual(beforeElapsed);
+    });
+
+    it('stop() でHeartbeatが停止されること', () => {
+      const eventSpy = vi.fn();
+      window.addEventListener('session_expired', eventSpy);
+
+      sessionService.start();
+      sessionService.stop();
+
+      // タイムアウト経過 + Heartbeat間隔経過
+      vi.advanceTimersByTime(1001 + 500);
+
+      // Heartbeatが停止しているので、イベントは発火しない
+      expect(eventSpy).not.toHaveBeenCalled();
+
+      window.removeEventListener('session_expired', eventSpy);
+    });
+  });
+
+  describe('IndexedDB対応確認', () => {
+    it('isIndexedDBSupported() でIndexedDB対応を確認できること', () => {
+      const isSupported = SessionService.isIndexedDBSupported();
+      expect(isSupported).toBe(true);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('複数回 start() を呼んでも問題なく動作すること', () => {
+      sessionService.start();
+      sessionService.start();
+
+      const state = sessionService.getSessionState();
+      expect(state.status).toBe('active');
+    });
+
+    it('stop() を複数回呼んでも問題なく動作すること', () => {
+      sessionService.start();
+      sessionService.stop();
+      sessionService.stop();
+
+      // エラーが発生しないことを確認
+      expect(true).toBe(true);
+    });
+
+    it('start() なしで stop() を呼んでも問題なく動作すること', () => {
+      sessionService.stop();
+
+      // エラーが発生しないことを確認
+      expect(true).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 🎯 目的

ボトムナビゲーションの「潮汐」タブを削除し、コードベースを簡素化します。

## 📝 背景

- 潮汐グラフ機能は既に**記録詳細画面**（FishingRecordDetail → TideIntegration → TideChart）に実装済み
- ボトムナビゲーションの潮汐タブは未実装のプレースホルダーで、混乱を招いていた
- 重複機能を避け、実装済み機能に集中するため削除

## 🔧 変更内容

### ModernApp.tsx (約100行削除)
- `activeTab`型定義から`'tide'`を削除
- `navigationItems`から潮汐タブオブジェクトを削除
- `TideContent`コンポーネント全体を削除（90行）
- `getHeaderTitle/getHeaderSubtitle`から`'tide'`ケースを削除
- `renderContent`から`'tide'`ケースを削除

### App.tsx (約30行削除)
- `activeTab`型定義から`'tide-chart'`を削除
- `TAB_TEST_IDS`から`'tide-chart'`を削除
- `TabButton`型定義から`'tide-chart'`を削除
- 潮汐タブボタンを削除
- TideChart表示ブロック全体を削除
- 未使用のTideChartインポートを削除

### src/constants/testIds.ts (1行削除)
- `TIDE_GRAPH_TAB`定数を削除

### tests/unit/session-service.test.ts
- 新規ファイル（git statusで検出、別コミットの可能性）

## ✅ 確認事項

- ✅ ビルド成功: `✓ built in 6.83s`
- ✅ TypeScriptコンパイルエラー解消
- ✅ 潮汐グラフ機能は記録詳細画面で引き続き利用可能

## 📸 Before/After

**Before:**
- ボトムナビゲーションに「潮汐🌊」タブが存在
- タップすると「潮汐グラフ表示機能は現在開発中です」メッセージ

**After:**
- ボトムナビゲーションから潮汐タブが削除
- 潮汐グラフは記録詳細画面でのみ利用可能（実装済み）

---

🚨 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>