### PR TITLE
fix(test): resolve Session Management E2E test failures (23 tests) - Issue #180

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,25 @@
 declare global {
   var __TEST_DB_NAME__: string | undefined;
+
+  // Session Management - Custom Event Types
+  interface SessionExpiredDetail {
+    lastActivityAt: number;
+    elapsedTime: number;
+  }
+
+  interface WindowEventMap {
+    session_expired: CustomEvent<SessionExpiredDetail>;
+  }
+
+  interface Window {
+    __sessionStore?: {
+      getState: () => {
+        isSessionExpiredModalOpen: boolean;
+        sessionStatus: string;
+        unsavedDataCount: number;
+      };
+    };
+  }
 }
 
 export {};


### PR DESCRIPTION
## Summary

Issue #180「Session Management E2E test failures (23 tests)」を修正しました。

### Root Cause

1. **CustomEventの型定義不足**
   - `session_expired`イベントのハンドラーが`CustomEvent`を正しく扱えていなかった
   - TypeScriptの型定義が不足していた

2. **E2Eテストの同期問題**
   - Zustand storeの状態更新とモーダル表示のタイミングがずれていた
   - テストがイベント発火後すぐに`toBeVisible()`をチェックしていた

## Changes

### 1. Global Type Definitions (`src/types/global.d.ts`)
- `SessionExpiredDetail` インターフェース追加
- `WindowEventMap` に `session_expired` イベント型を追加
- `Window.__sessionStore` をE2Eテスト用に追加

### 2. Session Store (`src/stores/session-store.ts`)
- イベントハンドラーを型安全な実装に変更
- 開発環境限定のデバッグログを追加
- `startSession()` で既存リスナーの二重登録を防止
- E2Eテスト用に `window.__sessionStore` を公開

### 3. E2E Tests (`tests/e2e/session-management.spec.ts`)
- `triggerSessionExpiredAndWaitForModal()` ヘルパー関数を追加
- Zustand状態更新を待機するロジックを追加
- イベントの `detail` プロパティを正しく設定
- タイムアウトを5秒→3秒に短縮（状態確認後）

## Test Results

- ✅ `npm run typecheck` - 型チェック成功
- ✅ `npm run build` - ビルド成功
- ⏳ CI結果確認中

## Reviews

- ✅ **tech-lead**: 型安全性、根本原因分析を確認
- ✅ **qa-engineer**: テスト戦略、同期ロジックを確認

## Addresses

以下の23件のSession Management E2Eテストに対応:

**session-management.spec.ts (7件)**
- TC-SM-002: セッション期限切れモーダルの表示
- TC-SM-003: 再接続ボタンのクリック
- TC-SM-004: エクスポートボタンのクリック
- TC-SM-005: Escapeキーでモーダルを閉じる
- TC-SM-006: ×ボタンでモーダルを閉じる
- TC-SM-007: アクセシビリティ - ARIA属性
- TC-SM-008: タッチターゲットサイズ

**session-management-extended.spec.ts (16件)**
- エッジケース、パフォーマンス、アクセシビリティ、レスポンシブテスト

## Related Issues

- Closes #180
- Part of #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
