### PR TITLE
hotfix(test): fix Recharts selector strict mode violations (Phase 1)

### DIFF
--- a/tests/e2e/tide-chart/helpers.ts
+++ b/tests/e2e/tide-chart/helpers.ts
@@ -196,7 +196,7 @@ export class TideChartPage {
   async expectChartRendered() {
     await this.expectVisible();
     await expect(this.page.locator('[role="img"]')).toBeVisible();
-    await expect(this.page.locator('.recharts-line')).toBeVisible();
+    await expect(this.page.locator('.recharts-line').first()).toBeVisible();
   }
 
   async expectAxisLabelsVisible() {
@@ -499,7 +499,8 @@ export class DeviceHelper {
 // Test Utilities
 export async function waitForChartLoad(page: Page) {
   await page.waitForSelector('[data-testid="tide-chart"]');
-  await page.waitForSelector('.recharts-line');
+  // Wait for at least one recharts line to be rendered (multiple may exist in CI)
+  await page.waitForSelector('.recharts-line >> nth=0');
   await page.waitForLoadState('networkidle');
 }
 

--- a/tests/e2e/tide-chart/integration-scenarios.spec.ts
+++ b/tests/e2e/tide-chart/integration-scenarios.spec.ts
@@ -29,7 +29,7 @@ test.describe('TC-E005: 統合シナリオテスト群', () => {
     await chartPage.expectChartRendered();
 
     // 2. データ確認
-    await expect(page.locator('.recharts-line')).toBeVisible();
+    await expect(page.locator('.recharts-line').first()).toBeVisible();
 
     // 3. データポイントインタラクション
     await chartPage.hoverDataPoint(0);


### PR DESCRIPTION
## Summary

**Phase 1緊急対応**: CI環境でのPlaywright strict mode違反を解消します。

Tech-Lead Review結果に基づき、PR #185の問題点を3つのPhaseに分けて対応。このPRはPhase 1（緊急）の対応です。

## Root Cause

**CI環境で `.recharts-line` セレクタが複数要素にマッチ:**
```
Error: strict mode violation:
locator('.recharts-line') resolved to 2 elements
```

**影響範囲:**
- TC-E004-005: should handle large dataset with sampling（失敗）
- TC-E005-001: Complete user flow（失敗の可能性）

## Changes

### 1. integration-scenarios.spec.ts (Line 32)

```diff
- await expect(page.locator('.recharts-line')).toBeVisible();
+ await expect(page.locator('.recharts-line').first()).toBeVisible();
```

### 2. helpers.ts - expectChartRendered() (Line 199)

```diff
  async expectChartRendered() {
    await this.expectVisible();
    await expect(this.page.locator('[role="img"]')).toBeVisible();
-   await expect(this.page.locator('.recharts-line')).toBeVisible();
+   await expect(this.page.locator('.recharts-line').first()).toBeVisible();
  }
```

### 3. helpers.ts - waitForChartLoad() (Line 503)

```diff
  export async function waitForChartLoad(page: Page) {
    await page.waitForSelector('[data-testid="tide-chart"]');
-   await page.waitForSelector('.recharts-line');
+   // Wait for at least one recharts line to be rendered (multiple may exist in CI)
+   await page.waitForSelector('.recharts-line >> nth=0');
    await page.waitForLoadState('networkidle');
  }
```

## Tech-Lead Review Context

**このPRは3つのPhaseのうちの Phase 1:**

- ✅ **Phase 1 (このPR)**: Recharts Selector修正漏れの修正（緊急）
- 🔄 Phase 2: Performance劣化の根本原因調査（Issue作成予定）
- 🔄 Phase 3: Visual Regression Tests有効化（Issue作成予定）

**なぜ複数の `.recharts-line` が存在するか？**
- 根本原因はPhase 2で調査予定
- 可能性: React Strict Modeの二重レンダリング、コンポーネント重複マウント、Rechartsライブラリの動作

## Test Results

⏳ CI実行中

## Future Work

- Phase 2 Issue: TideChart Performance劣化の根本原因調査（463ms→744ms）
- Phase 3 Issue: Visual Regression Tests有効化（CI環境でのスナップショット生成）
- 根本原因調査: なぜCI環境で複数の `.recharts-line` が存在するのか？

## Related

- PR #185: ドラフト化（tech-lead reviewにより）
- Tech-Lead Review: 評価 2/5 - 根本原因解決が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>