### PR TITLE
hotfix(workflow): add write permissions for snapshot workflow

### DIFF
--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   update-snapshots:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Visual Regression Snapshot生成ワークフローで403 Forbiddenエラーが発生:

```
remote: Permission to yuusuke0324/bite-note.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/yuusuke0324/bite-note/': The requested URL returned error: 403
```

## Root Cause

GitHub Actions tokenにwrite権限がなかった。

## Solution

`permissions: contents: write` を追加。

## Test

このPRマージ後、ワークフロー再実行で確認。