### PR TITLE
fix(test): Fix Session Management E2E test failures (~23 tests)

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -19,6 +19,7 @@ declare global {
         unsavedDataCount: number;
       };
     };
+    sessionServiceStarted?: boolean;
   }
 }
 

--- a/tests/e2e/session-management-extended.spec.ts
+++ b/tests/e2e/session-management-extended.spec.ts
@@ -11,6 +11,22 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
 
     // アプリが初期化されるまで待機
     await page.waitForSelector('[data-app-initialized]', { timeout: 10000 });
+
+    // セッション管理の初期化を待機
+    await page.waitForFunction(() => {
+      // @ts-expect-error - テスト用
+      return window.sessionServiceStarted === true;
+    }, { timeout: 5000 });
+
+    // Zustand storeが利用可能か確認
+    const hasSessionStore = await page.evaluate(() => {
+      // @ts-expect-error - テスト用
+      return typeof window.__sessionStore !== 'undefined';
+    });
+
+    if (!hasSessionStore) {
+      throw new Error('window.__sessionStore is not available. Check environment variables.');
+    }
   });
 
   test.describe('異常系テスト', () => {
@@ -40,7 +56,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
       });
 
       // モーダルが表示されるまで待機
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       // ページをリロード
       await page.reload();
@@ -73,7 +89,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
       });
 
       const modal = page.locator(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
-      await expect(modal).toBeVisible({ timeout: 5000 });
+      await expect(modal).toBeVisible({ timeout: 10000 });
 
       // 未保存データカウントが表示されていることを確認
       await expect(modal).toContainText('保存されていない釣果記録が5件あります');
@@ -89,7 +105,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
       });
 
       const modal = page.locator(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
-      await expect(modal).toBeVisible({ timeout: 5000 });
+      await expect(modal).toBeVisible({ timeout: 10000 });
 
       // カウントメッセージが表示されていないことを確認
       await expect(modal).not.toContainText('保存されていない釣果記録が');
@@ -118,7 +134,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`
@@ -143,7 +159,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`
@@ -164,7 +180,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`
@@ -189,7 +205,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       // 確認ダイアログのハンドラーを設定
       page.on('dialog', async (dialog) => {
@@ -205,7 +221,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
       // モーダルが閉じていないことを確認（キャンセルしたので）
       await expect(
         page.locator(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`)
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 10000 });
     });
   });
 
@@ -220,7 +236,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const endTime = Date.now();
       const displayTime = endTime - startTime;
@@ -241,7 +257,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const startTime = Date.now();
 
@@ -270,7 +286,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       // 再接続ボタンにフォーカスが当たっていることを確認
       const reconnectButton = page.locator(
@@ -286,7 +302,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`
@@ -321,16 +337,16 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       // モーダルタイトルが存在し、aria-labelledbyで参照されていることを確認
       const title = page.locator('#modal-title');
-      await expect(title).toBeVisible();
+      await expect(title).toBeVisible({ timeout: 10000 });
       await expect(title).toContainText('セッションが期限切れになりました');
 
       // モーダル説明が存在し、aria-describedbyで参照されていることを確認
       const description = page.locator('#modal-description');
-      await expect(description).toBeVisible();
+      await expect(description).toBeVisible({ timeout: 10000 });
       await expect(description).toContainText('しばらく操作がなかったため');
     });
   });
@@ -348,7 +364,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`
@@ -375,7 +391,7 @@ test.describe('Session Management - Extended Tests (Phase 3-4)', () => {
         window.dispatchEvent(event);
       });
 
-      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`);
+      await page.waitForSelector(`[data-testid="${TestIds.SESSION_TIMEOUT_MODAL}"]`, { timeout: 5000 });
 
       const reconnectButton = page.locator(
         `[data-testid="${TestIds.RECONNECT_AND_SAVE_BUTTON}"]`


### PR DESCRIPTION
## 概要

Session Management E2Eテスト失敗（約23件）を修正しました。

## 根本原因

QAエンジニアの分析により、以下の3つの問題を特定：

1. **Zustand Store状態の非同期更新遅延**
   - `expireSession()`が2回の`set()`呼び出しを行い、タイミング問題を引き起こしていた
   
2. **グローバル変数露出のタイミング問題**
   - E2E環境で`window.__sessionStore`が正しく認識されない可能性
   
3. **セッション管理初期化のタイミング問題**
   - テストがセッション管理の初期化完了前に実行されていた

## 修正内容

### アプリケーションコード

#### 1. `src/stores/session-store.ts`
- **修正1-1**: `expireSession()`で状態を一度にまとめて更新（Zustandの非同期バッチ処理を回避）
- **修正1-2**: `startSession()`/`stopSession()`で`window.sessionServiceStarted`フラグを設定
- **セキュリティ修正**: 本番環境でグローバル変数を露出しない（`!import.meta.env.PROD`でガード）

#### 2. `src/types/global.d.ts`
- `Window`インターフェースに`sessionServiceStarted?: boolean`を追加

### E2Eテストコード

#### 3. `tests/e2e/session-management.spec.ts`
- **修正2-1**: `beforeEach`でセッション管理初期化の確実な待機
- **修正2-2**: タイムアウト値の適正化（2秒→5秒、3秒→5秒）
- イベント処理完了待ちに100msの遅延を追加

#### 4. `tests/e2e/session-management-extended.spec.ts`
- **修正2-3**: 全テストの待機ロジック統一
- すべての`toBeVisible()`に`{ timeout: 10000 }`を追加
- すべての`waitForSelector`に`{ timeout: 5000 }`を追加

## テスト結果

- ✅ **ユニットテスト**: 全て成功（Session Management関連）
- ⚠️ **既存の失敗**: 2件（TideChart、FieldValidationIndicator - 今回の修正とは無関係）

## レビュー

- ✅ **QA Engineer**: 根本原因分析と修正方針提案
- ✅ **Tech Lead**: コード品質、セキュリティレビュー（Blocker修正完了）

## 期待される成果

- **現在**: 3/25件成功（12%）
- **修正後**: 25/25件成功（100%）を目標

## 関連Issue

Closes #194

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)