### PR TITLE
fix(test): Fix TideChart E2E test failures - Phase 1

### DIFF
--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -41,7 +41,7 @@ export async function createTestFishingRecord(
   const testRecord = { ...defaultTestRecord, ...record };
 
   // 記録登録タブに移動
-  await page.click('[data-testid="form-tab"]');
+  await page.click('[data-testid="nav-form"]');
   await page.waitForSelector(`[data-testid="${TestIds.LOCATION_NAME}"]`, { state: 'visible' });
 
   // フォーム入力
@@ -87,10 +87,12 @@ export async function navigateToRecordsList(page: Page): Promise<void> {
 }
 
 /**
- * 潮汐グラフタブを開く
+ * 潮汐グラフセクションを開く
  */
 export async function openTideGraphTab(page: Page): Promise<void> {
-  await page.click(`[data-testid="${TestIds.TIDE_GRAPH_TAB}"]`);
+  // 潮汐グラフトグルボタンをクリック
+  await page.click(`[data-testid="${TestIds.TIDE_GRAPH_TOGGLE_BUTTON}"]`);
+  // グラフが表示されるまで待機
   await page.waitForSelector(`[data-testid="${TestIds.TIDE_GRAPH_CANVAS}"]`, { timeout: 10000 });
 }
 


### PR DESCRIPTION
## 概要

TideChart関連のE2Eテスト失敗（Issue #195）の修正 - Phase 1です。

## 根本原因（QAエンジニア分析）

1. **data-testidの不整合**
   - テストコード: `form-tab`
   - 実装コード: `nav-form`
   
2. **未定義のTestId使用**
   - `TestIds.TIDE_GRAPH_TAB`が存在しない

## 修正内容

### tests/e2e/helpers/test-helpers.ts

#### 修正1: createTestFishingRecord関数
```typescript
// 修正前
await page.click('[data-testid="form-tab"]');

// 修正後
await page.click('[data-testid="nav-form"]');
```

#### 修正2: openTideGraphTab関数
```typescript
// 修正前
await page.click(`[data-testid="${TestIds.TIDE_GRAPH_TAB}"]`);

// 修正後
await page.click(`[data-testid="${TestIds.TIDE_GRAPH_TOGGLE_BUTTON}"]`);
```

潮汐グラフはタブではなく、トグルボタンで表示されることが判明。

## 期待される成果

- **修正前**: 約26件失敗
- **Phase 1修正後**: 約6件失敗見込み（パフォーマンステストは残る可能性）

## 次のステップ

CI結果を確認し、追加の修正が必要かを判断します。

## 関連Issue

Related to #195（完全なクローズはCI結果確認後）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)