### PR TITLE
fix(test): Enable E2E test flags in production builds for CI compatibility (Issue #174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
 
     - name: Build application for E2E tests
       run: npm run build
+      env:
+        VITE_E2E_TEST: 'true'
 
     - name: Cache Playwright browsers
       uses: actions/cache@v4

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -100,9 +100,11 @@ export const useSessionStore = create<SessionStore>()(
 
         // E2Eテスト用フラグ設定
         // - 開発モード（MODE=development）
-        // - テストモード（MODE=test、CI環境のE2Eテスト）
-        // 本番デプロイ（MODE=production）では露出しない
-        if (typeof window !== 'undefined' && import.meta.env.MODE !== 'production') {
+        // - テストモード（MODE=test）
+        // - CI E2Eテスト（VITE_E2E_TEST=true、production buildでも露出）
+        // 本番デプロイでは露出しない
+        if (typeof window !== 'undefined' &&
+            (import.meta.env.MODE !== 'production' || import.meta.env.VITE_E2E_TEST === 'true')) {
           window.sessionServiceStarted = true;
         }
       },
@@ -121,7 +123,8 @@ export const useSessionStore = create<SessionStore>()(
         }
 
         // E2Eテスト用フラグリセット
-        if (typeof window !== 'undefined' && import.meta.env.MODE !== 'production') {
+        if (typeof window !== 'undefined' &&
+            (import.meta.env.MODE !== 'production' || import.meta.env.VITE_E2E_TEST === 'true')) {
           window.sessionServiceStarted = false;
         }
       },
@@ -353,9 +356,11 @@ export const selectUnsavedDataCount = (state: SessionStore) => state.unsavedData
 
 // E2Eテスト用のグローバルアクセス
 // - 開発モード（MODE=development）
-// - テストモード（MODE=test、CI環境のE2Eテスト）
-// 本番デプロイ（MODE=production）では露出しない
-if (typeof window !== 'undefined' && import.meta.env.MODE !== 'production') {
+// - テストモード（MODE=test）
+// - CI E2Eテスト（VITE_E2E_TEST=true、production buildでも露出）
+// 本番デプロイでは露出しない
+if (typeof window !== 'undefined' &&
+    (import.meta.env.MODE !== 'production' || import.meta.env.VITE_E2E_TEST === 'true')) {
   window.__sessionStore = useSessionStore;
 
   // デバッグ用: グローバル露出を確認

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_E2E_TEST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 概要

Issue #174の根本的な解決として、CI環境でのproduction buildにおいてもE2Eテストフラグが正しく露出されるように修正しました。

## 問題の詳細

PR #199マージ後、main branchのCIで79件のE2Eテスト失敗が発生:
- Session Management Tests: 47件失敗
- Tide Integration Tests: 21件失敗  
- PWA Tests: 11件失敗

### 根本原因

1. **CI環境の特性**
   - CIでは `npm run build` でproduction buildを実行
   - `import.meta.env.MODE === 'production'`

2. **前回の修正の問題**
   - PR #199で `import.meta.env.MODE !== 'production'` に変更
   - production buildでは条件が `false` となり、テストフラグが露出されない
   - E2Eテストが `window.sessionServiceStarted` などにアクセスできず失敗

## 解決策

環境変数 `VITE_E2E_TEST` を導入し、CI環境でのproduction buildでもテストフラグを露出:

### 1. CI Workflow修正 (.github/workflows/ci.yml)

```yaml
- name: Build application for E2E tests
  run: npm run build
  env:
    VITE_E2E_TEST: 'true'
```

### 2. Session Store修正 (src/stores/session-store.ts)

3箇所の条件を更新:
```typescript
if (typeof window !== 'undefined' &&
    (import.meta.env.MODE !== 'production' || import.meta.env.VITE_E2E_TEST === 'true')) {
  // テストフラグを露出
}
```

### 3. TypeScript型定義追加 (src/vite-env.d.ts)

```typescript
interface ImportMetaEnv {
  readonly VITE_E2E_TEST?: string;
}
```

## 期待される効果

- ✅ ローカル開発環境: 変更なし（dev/testモードで従来通り動作）
- ✅ CI環境: production buildでもE2Eテストフラグが露出
- ✅ 本番デプロイ: `VITE_E2E_TEST` 未設定のため、テストフラグは露出されない（セキュリティ維持）
- ✅ **目標**: main branchの79件の失敗テストを全て解消

## テスト結果

### ローカルテスト
```bash
VITE_E2E_TEST=true npm run build
# ✅ ビルド成功 (6.57s)
```

### CI確認予定
- [ ] Session Management Tests (47件) → すべて成功
- [ ] Tide Integration Tests (21件) → すべて成功
- [ ] PWA Tests (11件) → すべて成功

## 関連Issue

Closes #174

## チェックリスト

- [x] ローカルでproduction buildが成功
- [x] TypeScript型定義を追加
- [x] CI workflowを更新
- [x] セキュリティ影響を確認（本番デプロイには影響なし）
- [ ] CI E2Eテストの成功を確認（PR作成後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)