### PR TITLE
fix(e2e): キーボードナビゲーションテストのタイミング問題修正

### DIFF
--- a/tests/e2e/fish-species-autocomplete.spec.ts
+++ b/tests/e2e/fish-species-autocomplete.spec.ts
@@ -115,17 +115,22 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
       // 候補が表示されるまで待機
       await expect(page.locator(`[data-testid="${TestIds.FISH_SPECIES_SUGGESTIONS}"]`)).toBeVisible();
 
+      // 候補リストを取得
+      const options = page.locator('[role="option"]');
+
       // ↓キーを押す
       await input.press('ArrowDown');
 
-      // 最初の候補が選択される
-      const firstOption = page.locator('[role="option"][aria-selected="true"]').first();
-      await expect(firstOption).toBeVisible();
+      // 最初の候補が選択される（React状態更新を待機）
+      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
 
       // もう一度↓キーを押す
       await input.press('ArrowDown');
 
-      // 2番目の候補が選択される
+      // 2番目の候補が選択される（React状態更新を待機）
+      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+
+      // 選択されている候補が1つだけであることを確認
       const selectedOptions = page.locator('[role="option"][aria-selected="true"]');
       const count = await selectedOptions.count();
       expect(count).toBe(1);
@@ -148,18 +153,18 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
 
       // ↓を押して最初の候補を選択
       await input.press('ArrowDown');
-      // 最初の候補が選択されていることを確認
-      await expect(options.first()).toHaveAttribute('aria-selected', 'true');
+      // 最初の候補が選択されていることを確認（React状態更新を待機）
+      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
 
       // もう一度↓を押して2番目の候補を選択
       await input.press('ArrowDown');
-      // 2番目の候補が選択されていることを確認
-      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true');
+      // 2番目の候補が選択されていることを確認（React状態更新を待機）
+      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
 
       // ↑を押して1番目の候補に戻る
       await input.press('ArrowUp');
-      // 1番目の候補が再び選択されていることを確認
-      await expect(options.first()).toHaveAttribute('aria-selected', 'true');
+      // 1番目の候補が再び選択されていることを確認（React状態更新を待機）
+      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
     });
 
     test('Enterキーで選択した候補を確定できる', async ({ page }) => {
@@ -170,6 +175,10 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
 
       // ↓キーで最初の候補を選択
       await input.press('ArrowDown');
+
+      // 候補が選択されていることを確認（React状態更新を待機）
+      const options = page.locator('[role="option"]');
+      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
 
       // Enterキーで確定
       await input.press('Enter');


### PR DESCRIPTION
## Summary

E2Eテスト `fish-species-autocomplete.spec.ts` のキーボードナビゲーションテストがCI環境で断続的に失敗する問題を修正しました。

## 根本原因

| 問題 | 説明 |
|------|------|
| React非同期更新 | `setSelectedIndex()`はマイクロタスクキューで処理 |
| DOM反映遅延 | 仮想DOM差分計算→実DOM更新に時間がかかる |
| Playwright即時解決 | `press()`はキーイベント発火後すぐにPromise解決 |
| CI環境での顕在化 | 低速CPU・共有リソースで遅延が大きくなる |

**特に2回目のArrowDownで失敗する理由:**
- 既存選択の解除（`aria-selected="false"`）+ 新規選択（`aria-selected="true"`）の2段階DOM更新が必要
- 1回目より処理が複雑で遅延が大きい

## 修正内容

キーボード操作後の`aria-selected`属性チェックに明示的な`timeout`オプションを追加:

```typescript
// Before（失敗）
await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true');

// After（成功）
await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
```

## 対象テスト

- `↓キーで候補を下に移動できる` (Line 110)
- `↑キーで候補を上に移動できる` (Line 139)
- `Enterキーで選択した候補を確定できる` (Line 170)

## 検証

- ローカル: `npx playwright test ... --repeat-each=5` → **5回連続成功**
- 冪等性担保済み

## Test plan

- [x] ローカルで対象テスト5回連続成功
- [x] 全E2Eテストスイート（20テスト）パス
- [ ] CI環境で成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)