### PR TITLE
fix(test): E2Eキーボードナビゲーションテストの堅牢化（waitForFunction使用）

### DIFF
--- a/tests/e2e/fish-species-autocomplete.spec.ts
+++ b/tests/e2e/fish-species-autocomplete.spec.ts
@@ -115,20 +115,24 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
       // 候補が表示されるまで待機
       await expect(page.locator(`[data-testid="${TestIds.FISH_SPECIES_SUGGESTIONS}"]`)).toBeVisible();
 
-      // 候補リストを取得
-      const options = page.locator('[role="option"]');
-
       // ↓キーを押す
       await input.press('ArrowDown');
 
-      // 最初の候補が選択される（React状態更新を待機）
-      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+      // waitForFunctionでDOM状態が完全に更新されるのを待機
+      await page.waitForFunction(() => {
+        const options = document.querySelectorAll('[role="option"]');
+        return options[0]?.getAttribute('aria-selected') === 'true';
+      }, { timeout: 5000 });
 
       // もう一度↓キーを押す
       await input.press('ArrowDown');
 
-      // 2番目の候補が選択される（React状態更新を待機）
-      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+      // waitForFunctionで2番目が選択され、1番目が選択解除されるのを待機
+      await page.waitForFunction(() => {
+        const options = document.querySelectorAll('[role="option"]');
+        return options[1]?.getAttribute('aria-selected') === 'true' &&
+               options[0]?.getAttribute('aria-selected') === 'false';
+      }, { timeout: 5000 });
 
       // 選択されている候補が1つだけであることを確認
       const selectedOptions = page.locator('[role="option"][aria-selected="true"]');
@@ -153,18 +157,29 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
 
       // ↓を押して最初の候補を選択
       await input.press('ArrowDown');
-      // 最初の候補が選択されていることを確認（React状態更新を待機）
-      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+      // waitForFunctionでDOM状態が完全に更新されるのを待機
+      await page.waitForFunction(() => {
+        const options = document.querySelectorAll('[role="option"]');
+        return options[0]?.getAttribute('aria-selected') === 'true';
+      }, { timeout: 5000 });
 
       // もう一度↓を押して2番目の候補を選択
       await input.press('ArrowDown');
-      // 2番目の候補が選択されていることを確認（React状態更新を待機）
-      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+      // waitForFunctionで2番目が選択され、1番目が選択解除されるのを待機
+      await page.waitForFunction(() => {
+        const options = document.querySelectorAll('[role="option"]');
+        return options[1]?.getAttribute('aria-selected') === 'true' &&
+               options[0]?.getAttribute('aria-selected') === 'false';
+      }, { timeout: 5000 });
 
       // ↑を押して1番目の候補に戻る
       await input.press('ArrowUp');
-      // 1番目の候補が再び選択されていることを確認（React状態更新を待機）
-      await expect(options.first()).toHaveAttribute('aria-selected', 'true', { timeout: 2000 });
+      // waitForFunctionで1番目が再び選択されるのを待機
+      await page.waitForFunction(() => {
+        const options = document.querySelectorAll('[role="option"]');
+        return options[0]?.getAttribute('aria-selected') === 'true' &&
+               options[1]?.getAttribute('aria-selected') === 'false';
+      }, { timeout: 5000 });
     });
 
     test('Enterキーで選択した候補を確定できる', async ({ page }) => {


### PR DESCRIPTION
## Summary

- E2Eキーボードナビゲーションテストで`page.waitForFunction()`を使用して、DOM状態の完全な更新を待機するように修正
- 単純なタイムアウト待機から、明示的なDOM状態検証に変更

## Root Cause Analysis

**問題**: ArrowDownを2回押した後、2番目の候補の`aria-selected`が`true`にならない

**根本原因**:
1. Reactの`setSelectedIndex()`は非同期で、DOMへの反映にラグがある
2. Playwrightの`press()`はキーイベント発火後すぐに解決する
3. CI環境ではタイミングが変動し、単純なタイムアウト（2000ms）では不十分

**解決策**:
- `toHaveAttribute(..., { timeout })` → `page.waitForFunction()` に変更
- **新規選択**と**旧選択解除**の両方の条件をチェック
- タイムアウトを5000msに増加

## Test Plan

- [x] ローカルで10回連続実行（5回×2テスト）- すべて成功
- [ ] CIで全E2Eテスト成功を確認

## Changes

- `tests/e2e/fish-species-autocomplete.spec.ts`
  - "↓キーで候補を下に移動できる" テストを修正
  - "↑キーで候補を上に移動できる" テストを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)