### PR TITLE
fix(test): flaky E2Eテスト修正（キーボードナビゲーション）

### DIFF
--- a/tests/e2e/fish-species-autocomplete.spec.ts
+++ b/tests/e2e/fish-species-autocomplete.spec.ts
@@ -157,29 +157,23 @@ test.describe('魚種オートコンプリート E2Eテスト', () => {
 
       // ↓を押して最初の候補を選択
       await input.press('ArrowDown');
-      // waitForFunctionでDOM状態が完全に更新されるのを待機
-      await page.waitForFunction(() => {
-        const options = document.querySelectorAll('[role="option"]');
-        return options[0]?.getAttribute('aria-selected') === 'true';
-      }, { timeout: 5000 });
+      // CI環境のタイミング問題対策：React状態更新を待機
+      await page.waitForTimeout(100);
+      await expect(options.nth(0)).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
 
       // もう一度↓を押して2番目の候補を選択
       await input.press('ArrowDown');
-      // waitForFunctionで2番目が選択され、1番目が選択解除されるのを待機
-      await page.waitForFunction(() => {
-        const options = document.querySelectorAll('[role="option"]');
-        return options[1]?.getAttribute('aria-selected') === 'true' &&
-               options[0]?.getAttribute('aria-selected') === 'false';
-      }, { timeout: 5000 });
+      // CI環境のタイミング問題対策：React状態更新を待機
+      await page.waitForTimeout(100);
+      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+      await expect(options.nth(0)).toHaveAttribute('aria-selected', 'false', { timeout: 5000 });
 
       // ↑を押して1番目の候補に戻る
       await input.press('ArrowUp');
-      // waitForFunctionで1番目が再び選択されるのを待機
-      await page.waitForFunction(() => {
-        const options = document.querySelectorAll('[role="option"]');
-        return options[0]?.getAttribute('aria-selected') === 'true' &&
-               options[1]?.getAttribute('aria-selected') === 'false';
-      }, { timeout: 5000 });
+      // CI環境のタイミング問題対策：React状態更新を待機
+      await page.waitForTimeout(100);
+      await expect(options.nth(0)).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+      await expect(options.nth(1)).toHaveAttribute('aria-selected', 'false', { timeout: 5000 });
     });
 
     test('Enterキーで選択した候補を確定できる', async ({ page }) => {


### PR DESCRIPTION
## Summary
- fish-species-autocomplete.spec.tsの「↑キーで候補を上に移動できる」テストがCI環境でflakyな問題を修正
- `waitForFunction`をPlaywrightの`expect().toHaveAttribute()`に置き換え

## Root Cause
1. **React状態更新のCI環境での遅延** - `setSelectedIndex`の非同期処理がバッチ処理され、DOM反映が遅れる
2. **`waitForFunction`の同時条件チェック** - 2つのDOM状態を同時に期待していたため、状態遷移の途中でタイムアウト

## Changes
- `waitForFunction`をPlaywrightの`expect().toHaveAttribute()`に置き換え
- 段階的な状態確認によりCI環境のタイミング問題に対応
- Playwrightの自動リトライ機能を活用

## Test plan
- [x] ローカルで5回連続テスト実行（全パス）
- [ ] CI E2Eテストパス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)