### PR TITLE
feat(ui): add Lucide React icon library foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "immer": "^10.0.3",
         "leaflet": "^1.9.4",
         "leaflet.heat": "^0.2.0",
+        "lucide-react": "^0.555.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.62.0",
@@ -6287,6 +6288,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.555.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
+      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "immer": "^10.0.3",
     "leaflet": "^1.9.4",
     "leaflet.heat": "^0.2.0",
+    "lucide-react": "^0.555.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.62.0",

--- a/src/components/__tests__/Icon.test.tsx
+++ b/src/components/__tests__/Icon.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Iconコンポーネントの単体テスト
+ *
+ * @description
+ * Lucide Reactベースの統一アイコンコンポーネントのテストスイート
+ * CI環境での並列実行時のDOM参照問題を回避するため、
+ * `screen` → `container.querySelector` パターンを採用
+ *
+ * @version 1.0.0
+ * @since 2025-11-26 Issue #208
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, within } from '@testing-library/react';
+import { Search, Fish, Camera, Home } from 'lucide-react';
+import { Icon } from '../ui/Icon';
+import { ICON_SIZES } from '../../types/icon';
+
+describe('Icon', () => {
+  beforeEach(async () => {
+    // CI環境でのJSDOM初期化待機
+    if (process.env.CI) {
+      await waitFor(
+        () => {
+          if (!document.body || document.body.children.length === 0) {
+            throw new Error('JSDOM not ready');
+          }
+        },
+        { timeout: 5000, interval: 100 }
+      );
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  });
+
+  afterEach(() => {
+    // CI環境ではroot containerを保持
+    if (!process.env.CI) {
+      document.body.innerHTML = '';
+    }
+  });
+
+  describe('基本レンダリング', () => {
+    it('アイコンコンポーネントを正しくレンダリングする', () => {
+      const { container } = render(<Icon icon={Search} aria-label="検索" />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute('aria-label', '検索');
+    });
+
+    it('SVG要素としてレンダリングされる', () => {
+      const { container } = render(<Icon icon={Fish} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      expect(svg?.tagName.toLowerCase()).toBe('svg');
+    });
+  });
+
+  describe('サイズ設定', () => {
+    it.each([
+      ['xs', ICON_SIZES.xs],
+      ['sm', ICON_SIZES.sm],
+      ['md', ICON_SIZES.md],
+      ['lg', ICON_SIZES.lg],
+      ['xl', ICON_SIZES.xl],
+    ] as const)(
+      'size="%s" でサイズ %dpx が適用される',
+      (preset, expectedSize) => {
+        const { container } = render(
+          <Icon icon={Camera} size={preset} decorative />
+        );
+        const svg = container.querySelector('svg');
+        expect(svg).toHaveAttribute('width', String(expectedSize));
+        expect(svg).toHaveAttribute('height', String(expectedSize));
+      }
+    );
+
+    it('数値でサイズを直接指定できる', () => {
+      const { container } = render(<Icon icon={Home} size={28} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '28');
+      expect(svg).toHaveAttribute('height', '28');
+    });
+
+    it('デフォルトでmd（20px）が適用される', () => {
+      const { container } = render(<Icon icon={Search} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '20');
+      expect(svg).toHaveAttribute('height', '20');
+    });
+  });
+
+  describe('ストローク幅', () => {
+    it('デフォルトのstrokeWidthは2', () => {
+      const { container } = render(<Icon icon={Fish} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('stroke-width', '2');
+    });
+
+    it('カスタムstrokeWidthを適用できる', () => {
+      const { container } = render(
+        <Icon icon={Fish} strokeWidth={1.5} decorative />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('stroke-width', '1.5');
+    });
+  });
+
+  describe('クラス名', () => {
+    it('flex-shrink-0クラスがデフォルトで適用される', () => {
+      const { container } = render(<Icon icon={Search} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('flex-shrink-0');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      const { container } = render(
+        <Icon icon={Camera} className="text-blue-600 custom-class" decorative />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('text-blue-600');
+      expect(svg).toHaveClass('custom-class');
+      expect(svg).toHaveClass('flex-shrink-0');
+    });
+
+    it('colorプリセットでカラークラスが適用される', () => {
+      const { container } = render(
+        <Icon icon={Home} color="primary" decorative />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('text-blue-600');
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('aria-labelを設定できる', () => {
+      const { container } = render(
+        <Icon icon={Search} aria-label="検索アイコン" />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('aria-label', '検索アイコン');
+    });
+
+    it('aria-label設定時はrole="img"が付与される', () => {
+      const { container } = render(
+        <Icon icon={Fish} aria-label="魚アイコン" />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('role', 'img');
+      expect(svg).toHaveAttribute('aria-label', '魚アイコン');
+    });
+
+    it('decorative=trueでaria-hidden="true"が設定される', () => {
+      const { container } = render(<Icon icon={Camera} decorative />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('decorative=trueの場合はaria-labelがあってもrole="img"は付与されない', () => {
+      const { container } = render(
+        <Icon icon={Home} aria-label="ホーム" decorative />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).not.toHaveAttribute('role');
+    });
+
+    it('aria-labelがない場合はaria-hidden="true"が設定される', () => {
+      const { container } = render(<Icon icon={Search} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('追加プロパティ', () => {
+    it('data-testid等の追加属性を渡せる', () => {
+      const { container } = render(
+        <Icon icon={Fish} data-testid="fish-icon" decorative />
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('data-testid', 'fish-icon');
+    });
+  });
+});

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,0 +1,69 @@
+import type { LucideIcon, LucideProps } from 'lucide-react';
+import { ICON_SIZES, ICON_COLORS, type IconSize, type IconColor } from '../../types/icon';
+
+export interface IconProps extends Omit<LucideProps, 'ref' | 'size'> {
+  /** Lucideアイコンコンポーネント */
+  icon: LucideIcon;
+  /** アイコンサイズ（プリセットまたはpx値） */
+  size?: IconSize | number;
+  /** ストローク幅 */
+  strokeWidth?: number;
+  /** カラープリセット */
+  color?: IconColor;
+  /** カスタムクラス名 */
+  className?: string;
+  /** アクセシビリティラベル */
+  'aria-label'?: string;
+  /** 装飾的アイコンかどうか（aria-hidden=true） */
+  decorative?: boolean;
+}
+
+/**
+ * 統一されたアイコンコンポーネント
+ *
+ * @example
+ * ```tsx
+ * import { Search } from 'lucide-react';
+ * <Icon icon={Search} size="md" aria-label="検索" />
+ * <Icon icon={Search} size={20} decorative />
+ * ```
+ */
+export const Icon: React.FC<IconProps> = ({
+  icon: IconComponent,
+  size = 'md',
+  strokeWidth = 2,
+  color = 'inherit',
+  className = '',
+  'aria-label': ariaLabel,
+  decorative = false,
+  ...props
+}) => {
+  // サイズの解決：プリセット名またはピクセル値
+  const resolvedSize = typeof size === 'string' ? ICON_SIZES[size] : size;
+
+  // カラークラスの取得
+  const colorClass = ICON_COLORS[color];
+
+  // クラス名の結合
+  const combinedClassName = [
+    'flex-shrink-0',
+    colorClass,
+    className,
+  ].filter(Boolean).join(' ');
+
+  return (
+    <IconComponent
+      size={resolvedSize}
+      strokeWidth={strokeWidth}
+      className={combinedClassName}
+      aria-label={ariaLabel}
+      aria-hidden={decorative || !ariaLabel}
+      role={ariaLabel && !decorative ? 'img' : undefined}
+      {...props}
+    />
+  );
+};
+
+Icon.displayName = 'Icon';
+
+export default Icon;

--- a/src/constants/__tests__/icon-mappings.test.ts
+++ b/src/constants/__tests__/icon-mappings.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ICON_MAPPINGS,
+  getIconsByCategory,
+  getIconFromEmoji,
+  getIconMapping,
+  getAllCategories,
+  getIconMappingsCount,
+} from '../icon-mappings';
+import { Fish, Search, Waves } from 'lucide-react';
+
+describe('icon-mappings', () => {
+  describe('ICON_MAPPINGS定数', () => {
+    it('50種類以上のアイコンマッピングが定義されている', () => {
+      const count = Object.keys(ICON_MAPPINGS).length;
+      expect(count).toBeGreaterThanOrEqual(50);
+    });
+
+    it('各マッピングに必須プロパティが含まれている', () => {
+      Object.entries(ICON_MAPPINGS).forEach(([emoji, mapping]) => {
+        expect(mapping.icon).toBeDefined();
+        expect(mapping.description).toBeDefined();
+        expect(mapping.category).toBeDefined();
+        expect(typeof mapping.description).toBe('string');
+        expect(['navigation', 'data', 'action', 'weather', 'status', 'other']).toContain(
+          mapping.category
+        );
+      });
+    });
+
+    it('釣りアプリに必要な基本アイコンが含まれている', () => {
+      // 釣り・魚種
+      expect(ICON_MAPPINGS['🎣']).toBeDefined();
+      expect(ICON_MAPPINGS['🐟']).toBeDefined();
+
+      // ナビゲーション
+      expect(ICON_MAPPINGS['🏠']).toBeDefined();
+      expect(ICON_MAPPINGS['📊']).toBeDefined();
+      expect(ICON_MAPPINGS['⚙️']).toBeDefined();
+
+      // データ項目
+      expect(ICON_MAPPINGS['📍']).toBeDefined();
+      expect(ICON_MAPPINGS['📅']).toBeDefined();
+      expect(ICON_MAPPINGS['📏']).toBeDefined();
+
+      // 天気・潮汐
+      expect(ICON_MAPPINGS['🌊']).toBeDefined();
+      expect(ICON_MAPPINGS['🌤️']).toBeDefined();
+
+      // アクション
+      expect(ICON_MAPPINGS['🔍']).toBeDefined();
+      expect(ICON_MAPPINGS['💾']).toBeDefined();
+      expect(ICON_MAPPINGS['🗑️']).toBeDefined();
+
+      // ステータス
+      expect(ICON_MAPPINGS['✅']).toBeDefined();
+      expect(ICON_MAPPINGS['⚠️']).toBeDefined();
+    });
+  });
+
+  describe('getIconsByCategory', () => {
+    it('navigationカテゴリのアイコンを取得できる', () => {
+      const navIcons = getIconsByCategory('navigation');
+      expect(Object.keys(navIcons).length).toBeGreaterThan(0);
+
+      Object.values(navIcons).forEach((mapping) => {
+        expect(mapping.category).toBe('navigation');
+      });
+    });
+
+    it('dataカテゴリのアイコンを取得できる', () => {
+      const dataIcons = getIconsByCategory('data');
+      expect(Object.keys(dataIcons).length).toBeGreaterThan(0);
+
+      Object.values(dataIcons).forEach((mapping) => {
+        expect(mapping.category).toBe('data');
+      });
+    });
+
+    it('全カテゴリで重複なくマッピングが分類されている', () => {
+      const allCategories = getAllCategories();
+      const allEmojis = new Set<string>();
+
+      allCategories.forEach((category) => {
+        const icons = getIconsByCategory(category);
+        Object.keys(icons).forEach((emoji) => {
+          expect(allEmojis.has(emoji)).toBe(false);
+          allEmojis.add(emoji);
+        });
+      });
+
+      expect(allEmojis.size).toBe(getIconMappingsCount());
+    });
+  });
+
+  describe('getIconFromEmoji', () => {
+    it('存在する絵文字からアイコンを取得できる', () => {
+      const fishIcon = getIconFromEmoji('🐟');
+      expect(fishIcon).toBe(Fish);
+    });
+
+    it('検索アイコンを取得できる', () => {
+      const searchIcon = getIconFromEmoji('🔍');
+      expect(searchIcon).toBe(Search);
+    });
+
+    it('存在しない絵文字はundefinedを返す', () => {
+      const result = getIconFromEmoji('🦄');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getIconMapping', () => {
+    it('存在する絵文字からマッピング情報を取得できる', () => {
+      const mapping = getIconMapping('🌊');
+      expect(mapping).toBeDefined();
+      expect(mapping?.icon).toBe(Waves);
+      expect(mapping?.description).toBe('潮汐・海・大潮');
+      expect(mapping?.category).toBe('weather');
+    });
+
+    it('代替アイコンが定義されているマッピングを取得できる', () => {
+      const mapping = getIconMapping('🎣');
+      expect(mapping?.alternativeIcon).toBeDefined();
+    });
+
+    it('存在しない絵文字はundefinedを返す', () => {
+      const result = getIconMapping('❓');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAllCategories', () => {
+    it('全カテゴリを取得できる', () => {
+      const categories = getAllCategories();
+      expect(categories).toContain('navigation');
+      expect(categories).toContain('data');
+      expect(categories).toContain('action');
+      expect(categories).toContain('weather');
+      expect(categories).toContain('status');
+      expect(categories).toContain('other');
+    });
+
+    it('重複がない', () => {
+      const categories = getAllCategories();
+      const uniqueCategories = new Set(categories);
+      expect(uniqueCategories.size).toBe(categories.length);
+    });
+  });
+
+  describe('getIconMappingsCount', () => {
+    it('正確なマッピング数を返す', () => {
+      const count = getIconMappingsCount();
+      expect(count).toBe(Object.keys(ICON_MAPPINGS).length);
+    });
+  });
+});

--- a/src/constants/icon-mappings.ts
+++ b/src/constants/icon-mappings.ts
@@ -1,0 +1,599 @@
+/**
+ * 絵文字からLucideアイコンへのマッピング定数
+ * @module constants/icon-mappings
+ */
+
+import {
+  Fish,
+  Waves,
+  Edit,
+  PenTool,
+  Camera,
+  Settings,
+  Wrench,
+  Home,
+  BarChart3,
+  PieChart,
+  Search,
+  MapPin,
+  Navigation,
+  Calendar,
+  Ruler,
+  MessageSquare,
+  StickyNote,
+  TrendingUp,
+  TrendingDown,
+  Lightbulb,
+  Info,
+  Upload,
+  Share,
+  Download,
+  Trash2,
+  RotateCw,
+  RefreshCw,
+  Save,
+  Map,
+  CloudSun,
+  Sun,
+  Moon,
+  Droplet,
+  Droplets,
+  Anchor,
+  Check,
+  CheckCircle2,
+  X,
+  XCircle,
+  AlertTriangle,
+  AlertOctagon,
+  Loader2,
+  Wifi,
+  WifiOff,
+  Trophy,
+  Award,
+  FileText,
+  NotebookPen,
+  File,
+  Palette,
+  Lock,
+  ImageIcon,
+  Bell,
+  FlaskConical,
+  Sliders,
+  Eye,
+  FolderOpen,
+  Smartphone,
+  Hand,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+  Menu,
+  MoreVertical,
+  MoreHorizontal,
+  Filter,
+  SortAsc,
+  SortDesc,
+  Clock,
+  Star,
+  Heart,
+  Bookmark,
+  Target,
+  Wind,
+  Thermometer,
+  ArrowDown,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { IconCategory } from '../types/icon';
+
+/**
+ * アイコンマッピング型
+ */
+export interface IconMapping {
+  /** Lucideアイコンコンポーネント */
+  icon: LucideIcon;
+  /** 代替アイコン（オプション） */
+  alternativeIcon?: LucideIcon;
+  /** 用途説明 */
+  description: string;
+  /** カテゴリ */
+  category: IconCategory;
+}
+
+/**
+ * 絵文字からLucideアイコンへのマッピング定数
+ */
+export const ICON_MAPPINGS: Record<string, IconMapping> = {
+  // ========================================
+  // ナビゲーション・UI要素
+  // ========================================
+  '🎣': {
+    icon: Anchor,
+    alternativeIcon: Fish,
+    description: '釣り・アプリアイコン（釣り行為）',
+    category: 'navigation',
+  },
+  '✏️': {
+    icon: Edit,
+    alternativeIcon: PenTool,
+    description: '記録登録・編集',
+    category: 'navigation',
+  },
+  '📸': {
+    icon: Camera,
+    description: '写真・カメラ',
+    category: 'navigation',
+  },
+  '🔧': {
+    icon: Settings,
+    alternativeIcon: Wrench,
+    description: 'デバッグ・設定',
+    category: 'navigation',
+  },
+  '⚙️': {
+    icon: Settings,
+    description: '設定',
+    category: 'navigation',
+  },
+  '🏠': {
+    icon: Home,
+    description: 'ホーム',
+    category: 'navigation',
+  },
+  '📊': {
+    icon: BarChart3,
+    alternativeIcon: PieChart,
+    description: '統計・グラフ',
+    category: 'navigation',
+  },
+  '🔍': {
+    icon: Search,
+    description: '検索',
+    category: 'action',
+  },
+  '➕': {
+    icon: Plus,
+    description: '追加・新規作成',
+    category: 'action',
+  },
+  '◀️': {
+    icon: ChevronLeft,
+    description: '左へ・戻る',
+    category: 'navigation',
+  },
+  '▶️': {
+    icon: ChevronRight,
+    description: '右へ・進む',
+    category: 'navigation',
+  },
+  '▼': {
+    icon: ChevronDown,
+    description: '下へ・展開',
+    category: 'navigation',
+  },
+  '▲': {
+    icon: ChevronUp,
+    description: '上へ・折りたたみ',
+    category: 'navigation',
+  },
+  '☰': {
+    icon: Menu,
+    description: 'メニュー',
+    category: 'navigation',
+  },
+  '⋮': {
+    icon: MoreVertical,
+    alternativeIcon: MoreHorizontal,
+    description: 'その他のオプション',
+    category: 'navigation',
+  },
+
+  // ========================================
+  // データ項目
+  // ========================================
+  '🐟': {
+    icon: Fish,
+    description: '魚種',
+    category: 'data',
+  },
+  '📍': {
+    icon: MapPin,
+    alternativeIcon: Navigation,
+    description: '場所・GPS',
+    category: 'data',
+  },
+  '📅': {
+    icon: Calendar,
+    description: '日付',
+    category: 'data',
+  },
+  '📏': {
+    icon: Ruler,
+    description: 'サイズ',
+    category: 'data',
+  },
+  '💭': {
+    icon: MessageSquare,
+    alternativeIcon: StickyNote,
+    description: 'メモ・コメント',
+    category: 'data',
+  },
+  '📈': {
+    icon: TrendingUp,
+    description: '上昇トレンド',
+    category: 'data',
+  },
+  '📉': {
+    icon: TrendingDown,
+    description: '下降トレンド',
+    category: 'data',
+  },
+  '💡': {
+    icon: Lightbulb,
+    alternativeIcon: Info,
+    description: 'ヒント・情報',
+    category: 'data',
+  },
+  '🕐': {
+    icon: Clock,
+    description: '時刻・時間',
+    category: 'data',
+  },
+  '⭐': {
+    icon: Star,
+    description: 'お気に入り・評価',
+    category: 'data',
+  },
+  '❤️': {
+    icon: Heart,
+    description: 'いいね・お気に入り',
+    category: 'data',
+  },
+  '🔖': {
+    icon: Bookmark,
+    description: 'ブックマーク',
+    category: 'data',
+  },
+  '🎯': {
+    icon: Target,
+    description: 'ヒットポイント・狙いポイント',
+    category: 'data',
+  },
+
+  // ========================================
+  // アクション
+  // ========================================
+  '📤': {
+    icon: Upload,
+    alternativeIcon: Share,
+    description: 'エクスポート・共有',
+    category: 'action',
+  },
+  '📥': {
+    icon: Download,
+    description: 'インポート・ダウンロード',
+    category: 'action',
+  },
+  '🗑️': {
+    icon: Trash2,
+    description: '削除',
+    category: 'action',
+  },
+  '🔄': {
+    icon: RotateCw,
+    alternativeIcon: RefreshCw,
+    description: 'リロード・再試行・更新',
+    category: 'action',
+  },
+  '💾': {
+    icon: Save,
+    description: '保存',
+    category: 'action',
+  },
+  '🗺️': {
+    icon: Map,
+    description: '地図',
+    category: 'action',
+  },
+  '🎛️': {
+    icon: Filter,
+    alternativeIcon: Sliders,
+    description: 'フィルター',
+    category: 'action',
+  },
+  '↑': {
+    icon: SortAsc,
+    description: '昇順ソート',
+    category: 'action',
+  },
+  '↓': {
+    icon: SortDesc,
+    description: '降順ソート',
+    category: 'action',
+  },
+
+  // ========================================
+  // 天候・環境
+  // ========================================
+  '🌊': {
+    icon: Waves,
+    description: '潮汐・海・大潮',
+    category: 'weather',
+  },
+  '🌤️': {
+    icon: CloudSun,
+    alternativeIcon: Sun,
+    description: '天気',
+    category: 'weather',
+  },
+  '🌙': {
+    icon: Moon,
+    description: '月・ダークモード',
+    category: 'weather',
+  },
+  '☀️': {
+    icon: Sun,
+    description: 'ライトモード',
+    category: 'weather',
+  },
+  '💧': {
+    icon: Droplet,
+    alternativeIcon: Droplets,
+    description: '小潮',
+    category: 'weather',
+  },
+  '🏖️': {
+    icon: ArrowDown,
+    alternativeIcon: TrendingDown,
+    description: '干潮',
+    category: 'weather',
+  },
+  '💨': {
+    icon: Wind,
+    description: '風速・風向',
+    category: 'weather',
+  },
+  '🌡️': {
+    icon: Thermometer,
+    description: '気温・水温',
+    category: 'weather',
+  },
+
+  // ========================================
+  // ステータス・通知
+  // ========================================
+  '✓': {
+    icon: Check,
+    alternativeIcon: CheckCircle2,
+    description: '成功',
+    category: 'status',
+  },
+  '✗': {
+    icon: X,
+    alternativeIcon: XCircle,
+    description: 'エラー',
+    category: 'status',
+  },
+  '⚠️': {
+    icon: AlertTriangle,
+    description: '警告',
+    category: 'status',
+  },
+  'ℹ': {
+    icon: Info,
+    description: '情報',
+    category: 'status',
+  },
+  '🚨': {
+    icon: AlertOctagon,
+    description: '重大なエラー',
+    category: 'status',
+  },
+  '⏳': {
+    icon: Loader2,
+    description: '処理中・ローディング',
+    category: 'status',
+  },
+  '📡': {
+    icon: Wifi,
+    alternativeIcon: WifiOff,
+    description: 'オフライン',
+    category: 'status',
+  },
+  '✅': {
+    icon: CheckCircle2,
+    description: '利用可能',
+    category: 'status',
+  },
+
+  // ========================================
+  // その他
+  // ========================================
+  '🏆': {
+    icon: Trophy,
+    alternativeIcon: Award,
+    description: 'ベスト・ランキング',
+    category: 'other',
+  },
+  '📝': {
+    icon: FileText,
+    alternativeIcon: NotebookPen,
+    description: '記録・テキスト',
+    category: 'other',
+  },
+  '📄': {
+    icon: File,
+    description: 'データ・ドキュメント',
+    category: 'other',
+  },
+  '🎨': {
+    icon: Palette,
+    description: '表示・デザイン',
+    category: 'other',
+  },
+  '🔒': {
+    icon: Lock,
+    description: 'プライバシー',
+    category: 'other',
+  },
+  '📷': {
+    icon: ImageIcon,
+    description: '写真設定',
+    category: 'other',
+  },
+  '🔔': {
+    icon: Bell,
+    description: '通知',
+    category: 'other',
+  },
+  '🧪': {
+    icon: FlaskConical,
+    description: '実験的機能',
+    category: 'other',
+  },
+  '👁️': {
+    icon: Eye,
+    description: '表示オプション',
+    category: 'other',
+  },
+  '🗂️': {
+    icon: FolderOpen,
+    description: 'データ管理',
+    category: 'other',
+  },
+  '📱': {
+    icon: Smartphone,
+    description: 'モバイル・インストール',
+    category: 'other',
+  },
+  '👋': {
+    icon: Hand,
+    description: 'ウェルカム',
+    category: 'other',
+  },
+};
+
+/**
+ * カテゴリ別アイコン取得
+ * @param category - 取得するカテゴリ
+ * @returns 指定カテゴリのアイコンマッピング
+ */
+export function getIconsByCategory(
+  category: IconCategory
+): Record<string, IconMapping> {
+  return Object.entries(ICON_MAPPINGS)
+    .filter(([, mapping]) => mapping.category === category)
+    .reduce(
+      (acc, [emoji, mapping]) => ({ ...acc, [emoji]: mapping }),
+      {} as Record<string, IconMapping>
+    );
+}
+
+/**
+ * 絵文字からアイコンを取得
+ * @param emoji - 絵文字
+ * @returns Lucideアイコンコンポーネント（見つからない場合はundefined）
+ */
+export function getIconFromEmoji(emoji: string): LucideIcon | undefined {
+  return ICON_MAPPINGS[emoji]?.icon;
+}
+
+/**
+ * 絵文字からアイコンマッピング情報を取得
+ * @param emoji - 絵文字
+ * @returns アイコンマッピング情報（見つからない場合はundefined）
+ */
+export function getIconMapping(emoji: string): IconMapping | undefined {
+  return ICON_MAPPINGS[emoji];
+}
+
+/**
+ * すべてのカテゴリを取得
+ * @returns カテゴリの配列
+ */
+export function getAllCategories(): IconCategory[] {
+  const categories = new Set<IconCategory>();
+  Object.values(ICON_MAPPINGS).forEach((mapping) => {
+    categories.add(mapping.category);
+  });
+  return Array.from(categories);
+}
+
+/**
+ * マッピングされた絵文字の総数を取得
+ * @returns 絵文字の総数
+ */
+export function getIconMappingsCount(): number {
+  return Object.keys(ICON_MAPPINGS).length;
+}
+
+// よく使うアイコンの直接エクスポート（利便性のため）
+export {
+  Fish,
+  Waves,
+  Edit,
+  Camera,
+  Settings,
+  Home,
+  BarChart3,
+  Search,
+  MapPin,
+  Calendar,
+  Ruler,
+  MessageSquare,
+  TrendingUp,
+  TrendingDown,
+  Lightbulb,
+  Info,
+  Upload,
+  Download,
+  Trash2,
+  RotateCw,
+  Save,
+  Map,
+  CloudSun,
+  Sun,
+  Moon,
+  Droplet,
+  Droplets,
+  Anchor,
+  Check,
+  CheckCircle2,
+  X,
+  XCircle,
+  AlertTriangle,
+  AlertOctagon,
+  Loader2,
+  Wifi,
+  WifiOff,
+  Trophy,
+  FileText,
+  File,
+  Palette,
+  Lock,
+  ImageIcon,
+  Bell,
+  FlaskConical,
+  Sliders,
+  Eye,
+  FolderOpen,
+  Smartphone,
+  Hand,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+  Menu,
+  MoreVertical,
+  Filter,
+  Clock,
+  Star,
+  Heart,
+  Bookmark,
+  Target,
+  Wind,
+  Thermometer,
+  ArrowDown,
+};

--- a/src/types/icon.ts
+++ b/src/types/icon.ts
@@ -1,0 +1,56 @@
+/**
+ * アイコン関連の型定義
+ * @module types/icon
+ */
+
+/**
+ * アイコンサイズプリセット
+ */
+export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * アイコンサイズのピクセル値マッピング
+ */
+export const ICON_SIZES: Record<IconSize, number> = {
+  xs: 14,
+  sm: 16,
+  md: 20,
+  lg: 24,
+  xl: 32,
+};
+
+/**
+ * アイコンカラープリセット
+ */
+export type IconColor =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'info'
+  | 'inherit';
+
+/**
+ * アイコンカラーのTailwind CSSクラスマッピング
+ */
+export const ICON_COLORS: Record<IconColor, string> = {
+  primary: 'text-blue-600 dark:text-blue-400',
+  secondary: 'text-gray-600 dark:text-gray-400',
+  success: 'text-green-600 dark:text-green-400',
+  warning: 'text-yellow-600 dark:text-yellow-400',
+  error: 'text-red-600 dark:text-red-400',
+  info: 'text-blue-500 dark:text-blue-300',
+  inherit: '',
+};
+
+/**
+ * アイコンカテゴリ
+ */
+export type IconCategory =
+  | 'navigation'
+  | 'data'
+  | 'action'
+  | 'weather'
+  | 'status'
+  | 'other';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,10 @@ export type {
   LowSpecDeviceConfig,
 } from './fish-species';
 
+// アイコン関連（2025年11月追加）
+export type { IconSize, IconColor, IconCategory } from './icon';
+export { ICON_SIZES, ICON_COLORS } from './icon';
+
 // 定数のエクスポート
 export { SUPPORTED_IMAGE_TYPES } from './media';
 export { THEMES } from './state';

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -32,6 +32,7 @@ export default defineWorkspace([
         'src/components/common/__tests__/OfflineIndicator.test.tsx', // Phase 3-3追加
         'src/components/__tests__/ReAuthPrompt.test.tsx', // Issue #216追加
         'src/components/__tests__/TideTooltip.test.tsx', // Issue #249: TC-T013修正後に有効化
+        'src/components/__tests__/Icon.test.tsx', // Issue #208: アイコンコンポーネント
       ],
       setupFiles: ['./src/setupTests.ts'],
       environment: 'jsdom',


### PR DESCRIPTION
## Summary

Phase 1 of #207 (絵文字アイコンをプロフェッショナルなSVGアイコンライブラリに置き換え)

- **Lucide React導入**: `lucide-react` パッケージをインストール
- **共通Iconコンポーネント実装**: サイズ・カラープリセット、アクセシビリティ対応
- **アイコンマッピング定数作成**: 61種類の絵文字→SVGアイコンマッピング
- **型定義追加**: IconSize, IconColor, IconCategory
- **ユニットテスト実装**: 35テストケース

### 主な機能

1. **Icon.tsx** (`src/components/ui/Icon.tsx`)
   - サイズプリセット (xs/sm/md/lg/xl) または数値指定
   - カラープリセット (primary/secondary/success/warning/error/info)
   - アクセシビリティ (aria-label, decorative, role)
   - TypeScript型安全

2. **icon-mappings.ts** (`src/constants/icon-mappings.ts`)
   - 61種類のアイコンマッピング
   - 6カテゴリ (navigation, data, action, weather, status, other)
   - ヘルパー関数 (getIconsByCategory, getIconFromEmoji 等)

### Designer Reviewによる改善

- 🎣と🐟の視覚的区別 (🎣→Anchor, 🐟→Fish)
- 釣り特有アイコン追加 (🎯→Target, 💨→Wind, 🌡️→Thermometer)
- トレンドアイコン追加 (📈→TrendingUp, 📉→TrendingDown)
- 潮汐アイコン改善 (🏖️→ArrowDown)

## Test plan

- [x] `npm run test:fast` - 全1493テストパス
- [x] `npm run typecheck` - 型チェックパス
- [x] `npm run build` - ビルド成功
- [x] Tech-lead review: APPROVED
- [x] Designer review: 重要項目対応済み

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)