### PR TITLE
feat(ui): コアUIコンポーネントの絵文字をSVGアイコンに置き換え

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import { ErrorDisplay } from './components/errors'
 import { ToastContainer } from './components/ToastContainer'
 import { ReAuthPrompt } from './components/features/SessionManagement/ReAuthPrompt'
 import Button from './components/ui/Button'
+import { Icon } from './components/ui/Icon'
+import { Anchor, Edit, Camera, Wrench, AlertTriangle, Loader2, CheckCircle2, XCircle, BarChart3 } from 'lucide-react'
 import { colors } from './theme/colors'
 import { textStyles, typography } from './theme/typography'
 import type { CreateFishingRecordFormData } from './lib/validation'
@@ -302,7 +304,7 @@ function App() {
     debug: TestIds.DEBUG_TAB,
   } as const;
 
-  const TabButton = ({ tab, label, emoji }: { tab: 'form' | 'list' | 'debug', label: string, emoji: string }) => (
+  const TabButton = ({ tab, label, icon }: { tab: 'form' | 'list' | 'debug', label: string, icon: React.ReactNode }) => (
     <Button
       variant={activeTab === tab ? 'primary' : 'text'}
       size="md"
@@ -317,7 +319,7 @@ function App() {
         color: activeTab === tab ? colors.text.inverse : colors.text.primary,
       }}
     >
-      <span style={{ marginRight: '0.5rem' }}>{emoji}</span>
+      <span style={{ marginRight: '0.5rem', display: 'flex', alignItems: 'center' }}>{icon}</span>
       {label}
     </Button>
   );
@@ -336,7 +338,14 @@ function App() {
           ...textStyles.headline.large,
           color: colors.semantic.error.main,
           marginBottom: '1rem',
-        }}>⚠️ アプリケーションエラー</h1>
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '0.5rem',
+        }}>
+          <Icon icon={AlertTriangle} size="lg" color="error" aria-label="警告" />
+          アプリケーションエラー
+        </h1>
         <p style={{
           ...textStyles.body.large,
           color: colors.semantic.error.dark,
@@ -371,7 +380,13 @@ function App() {
             margin: 0,
             ...textStyles.headline.medium,
             color: colors.text.inverse,
-          }}>🎣 釣果記録アプリ</h1>
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+          }}>
+            <Icon icon={Anchor} size="lg" decorative />
+            釣果記録アプリ
+          </h1>
         </div>
 
       {/* タブナビゲーション */}
@@ -386,9 +401,9 @@ function App() {
           maxWidth: '1200px',
           margin: '0 auto'
         }}>
-          <TabButton tab="form" label="記録登録" emoji="✏️" />
-          <TabButton tab="list" label="写真で確認" emoji="📸" />
-          <TabButton tab="debug" label="デバッグ" emoji="🔧" />
+          <TabButton tab="form" label="記録登録" icon={<Icon icon={Edit} size="sm" decorative />} />
+          <TabButton tab="list" label="写真で確認" icon={<Icon icon={Camera} size="sm" decorative />} />
+          <TabButton tab="debug" label="デバッグ" icon={<Icon icon={Wrench} size="sm" decorative />} />
         </div>
       </div>
 
@@ -405,7 +420,13 @@ function App() {
               ...textStyles.headline.medium,
               color: colors.text.primary,
               marginBottom: '1.5rem',
-            }}>✏️ 新しい釣果を記録</h2>
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}>
+              <Icon icon={Edit} size="md" decorative />
+              新しい釣果を記録
+            </h2>
             <FishingRecordForm
               onSubmit={handleFormSubmit}
               isLoading={storeStatus === 'loading'}
@@ -429,7 +450,10 @@ function App() {
 
         {activeTab === 'debug' && (
           <div>
-            <h2>🔧 デバッグ情報</h2>
+            <h2 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <Icon icon={Wrench} size="md" decorative />
+              デバッグ情報
+            </h2>
 
             <div style={{
               padding: '1rem',
@@ -439,10 +463,10 @@ function App() {
               marginBottom: '1rem'
             }}>
               <h3>データベース状態</h3>
-              <p>
-                {dbStatus === 'loading' && '⏳ データベース接続中...'}
-                {dbStatus === 'success' && '✅ ' + dbMessage}
-                {dbStatus === 'error' && '❌ ' + dbMessage}
+              <p style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {dbStatus === 'loading' && <><Icon icon={Loader2} size="sm" className="animate-spin" decorative /> データベース接続中...</>}
+                {dbStatus === 'success' && <><Icon icon={CheckCircle2} size="sm" color="success" decorative /> {dbMessage}</>}
+                {dbStatus === 'error' && <><Icon icon={XCircle} size="sm" color="error" decorative /> {dbMessage}</>}
               </p>
             </div>
 
@@ -454,10 +478,10 @@ function App() {
               marginBottom: '1rem'
             }}>
               <h3>Zustand Store状態</h3>
-              <p>
-                {storeStatus === 'loading' && '⏳ ストアテスト中...'}
-                {storeStatus === 'success' && '✅ ' + storeMessage}
-                {storeStatus === 'error' && '❌ ' + storeMessage}
+              <p style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {storeStatus === 'loading' && <><Icon icon={Loader2} size="sm" className="animate-spin" decorative /> ストアテスト中...</>}
+                {storeStatus === 'success' && <><Icon icon={CheckCircle2} size="sm" color="success" decorative /> {storeMessage}</>}
+                {storeStatus === 'error' && <><Icon icon={XCircle} size="sm" color="error" decorative /> {storeMessage}</>}
               </p>
               {error && (
                 <p style={{ color: '#dc3545', fontSize: '0.9em' }}>
@@ -498,16 +522,16 @@ function App() {
             }}>
               <h3>開発進捗</h3>
               <ul>
-                <li>✅ TASK-001: プロジェクトセットアップ</li>
-                <li>✅ TASK-002: 型定義・インターフェース</li>
-                <li>✅ TASK-003: IndexedDBセットアップ</li>
-                <li>✅ TASK-101: 釣果記録データアクセスレイヤー</li>
-                <li>✅ TASK-102: 写真データアクセスレイヤー</li>
-                <li>✅ TASK-103: 位置情報・設定管理データアクセス層</li>
-                <li>✅ TASK-201: Zustand Store実装</li>
-                <li>✅ TASK-202: React Hook Form + Zod実装</li>
-                <li>✅ TASK-301: フォーム入力UI実装</li>
-                <li>✅ TASK-302: 記録一覧表示実装</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-001: プロジェクトセットアップ</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-002: 型定義・インターフェース</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-003: IndexedDBセットアップ</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-101: 釣果記録データアクセスレイヤー</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-102: 写真データアクセスレイヤー</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-103: 位置情報・設定管理データアクセス層</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-201: Zustand Store実装</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-202: React Hook Form + Zod実装</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-301: フォーム入力UI実装</li>
+                <li style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={CheckCircle2} size={14} color="success" decorative /> TASK-302: 記録一覧表示実装</li>
               </ul>
               <p style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
                 <strong>現在:</strong> 写真ベース記録一覧UI実装完了
@@ -520,7 +544,7 @@ function App() {
                 borderRadius: '4px',
                 border: '1px solid #ffeaa7'
               }}>
-                <strong>📊 現在のデータ状況:</strong>
+                <strong style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}><Icon icon={BarChart3} size={14} decorative /> 現在のデータ状況:</strong>
                 <br />記録数: {records.length}件
                 <br />記録詳細:
                 <pre style={{ fontSize: '0.75rem', maxHeight: '200px', overflow: 'auto', backgroundColor: '#fff', padding: '0.5rem', marginTop: '0.5rem' }}>

--- a/src/ModernApp.tsx
+++ b/src/ModernApp.tsx
@@ -40,6 +40,8 @@ import { OfflineIndicator } from './components/common/OfflineIndicator';
 
 // アイコン
 import Icons from './components/icons/Icons';
+import { Icon } from './components/ui/Icon';
+import { Search, Sliders, ChevronDown, Fish, MapPin, Ruler, Trophy, TrendingUp, Calendar } from 'lucide-react';
 
 // テスト用定数
 import { TestIds } from './constants/testIds';
@@ -581,11 +583,12 @@ function ModernApp() {
           left: '14px',
           top: '50%',
           transform: 'translateY(-50%)',
-          fontSize: '1.25rem',
           pointerEvents: 'none',
           color: colors.text.secondary,
+          display: 'flex',
+          alignItems: 'center',
         }}>
-          🔍
+          <Icon icon={Search} size="md" decorative />
         </span>
         {localValue && (
           <button
@@ -673,7 +676,7 @@ function ModernApp() {
         onClick={() => setIsExpanded(!isExpanded)}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <span style={{ fontSize: '1.25rem' }}>🎛️</span>
+            <Icon icon={Sliders} size="md" color="primary" decorative />
             <span style={{
               fontSize: '0.875rem',
               fontWeight: '600',
@@ -724,11 +727,12 @@ function ModernApp() {
               </button>
             )}
             <span style={{
-              fontSize: '1rem',
+              display: 'flex',
+              alignItems: 'center',
               transform: isExpanded ? 'rotate(180deg)' : 'rotate(0)',
               transition: 'transform 0.2s ease',
             }}>
-              ▼
+              <Icon icon={ChevronDown} size="sm" decorative />
             </span>
           </div>
         </div>
@@ -749,8 +753,12 @@ function ModernApp() {
                   fontWeight: '600',
                   color: colors.text.primary,
                   marginBottom: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
                 }}>
-                  🐟 魚種
+                  <Icon icon={Fish} size="sm" decorative />
+                  魚種
                 </div>
                 <div style={{
                   display: 'flex',
@@ -792,8 +800,12 @@ function ModernApp() {
                   fontWeight: '600',
                   color: colors.text.primary,
                   marginBottom: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
                 }}>
-                  📍 場所
+                  <Icon icon={MapPin} size="sm" decorative />
+                  場所
                 </div>
                 <div style={{
                   display: 'flex',
@@ -834,8 +846,12 @@ function ModernApp() {
                 fontWeight: '600',
                 color: colors.text.primary,
                 marginBottom: '8px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
               }}>
-                📏 サイズ範囲 (cm)
+                <Icon icon={Ruler} size="sm" decorative />
+                サイズ範囲 (cm)
               </div>
               <div style={{
                 display: 'flex',
@@ -906,7 +922,9 @@ function ModernApp() {
           padding: '48px 32px',
           color: colors.text.secondary,
         }}>
-          <div style={{ fontSize: '4rem', marginBottom: '16px' }}>🔍</div>
+          <div style={{ marginBottom: '16px', display: 'flex', justifyContent: 'center' }}>
+            <Icon icon={Search} size={64} color="secondary" decorative />
+          </div>
           <div style={{
             ...textStyles.headline.small,
             marginBottom: '8px',
@@ -1146,7 +1164,8 @@ function ModernApp() {
               alignItems: 'center',
               gap: '6px',
             }}>
-              🏆 {(() => {
+              <Icon icon={Trophy} size={16} decorative />
+              {(() => {
                 const bestSize = typeof record.size === 'number' ? record.size : 0;
                 const bestWeight = typeof record.weight === 'number' ? record.weight : 0;
                 const bestMax = Math.max(bestSize, bestWeight);
@@ -1176,8 +1195,12 @@ function ModernApp() {
               transform: isHovered ? 'translateY(-2px) scale(1.05)' : 'translateY(0) scale(1)',
               transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
               boxShadow: isHovered ? '0 4px 12px rgba(0, 0, 0, 0.15)' : '0 2px 4px rgba(0, 0, 0, 0.1)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
             }}>
-              📏 {record.size}cm
+              <Icon icon={Ruler} size={14} decorative />
+              {record.size}cm
             </div>
           ) : null}
 
@@ -1226,8 +1249,12 @@ function ModernApp() {
               color: 'white',
               textShadow: '0 2px 4px rgba(0,0,0,0.3)',
               transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
             }}>
-              🐟 {record.fishSpecies}
+              <Icon icon={Fish} size={20} decorative />
+              {record.fishSpecies}
             </h3>
 
             {/* 場所 */}
@@ -1483,7 +1510,8 @@ function ModernApp() {
               data={trendData}
               type="bar"
               height={200}
-              title="📈 釣果トレンド（最近6ヶ月）"
+              title="釣果トレンド（最近6ヶ月）"
+              titleIcon={<Icon icon={TrendingUp} size="sm" decorative />}
               color={colors.primary[500]}
             />
           </ModernCard>
@@ -1500,7 +1528,8 @@ function ModernApp() {
               alignItems: 'center',
               gap: '8px',
             }}>
-              🏆 今月のベストキャッチ
+              <Icon icon={Trophy} size="md" decorative />
+              今月のベストキャッチ
             </h2>
             <div style={{ maxWidth: '600px', margin: '0 auto' }}>
               <ModernRecordCard record={bestCatch} isBestCatch={true} />
@@ -1777,8 +1806,12 @@ function ModernApp() {
                   fontSize: '0.875rem',
                   color: colors.primary[700],
                   fontWeight: '500',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
                 }}>
-                  🔍 {filteredRecords.length}件の記録が見つかりました
+                  <Icon icon={Search} size="sm" decorative />
+                  {filteredRecords.length}件の記録が見つかりました
                 </span>
                 {(activeFilterCount > 0 || filters.searchQuery) && (
                   <button
@@ -1830,7 +1863,8 @@ function ModernApp() {
                         alignItems: 'center',
                         gap: '8px',
                       }}>
-                        📅 {group.label}
+                        <Icon icon={Calendar} size="sm" decorative />
+                        {group.label}
                         <span style={{
                           ...textStyles.body.small,
                           color: colors.text.secondary,

--- a/src/components/FishingRecordCard.tsx
+++ b/src/components/FishingRecordCard.tsx
@@ -5,6 +5,8 @@ import { LocationDisplay } from './LocationDisplay';
 import { photoService } from '../lib/photo-service';
 import type { FishingRecord } from '../types';
 import { logger } from '../lib/errors/logger';
+import { Icon } from './ui/Icon';
+import { Fish, Calendar, Ruler, Map, MessageCircle, Camera, Edit, Trash2 } from 'lucide-react';
 
 interface FishingRecordCardProps {
   record: FishingRecord;
@@ -145,7 +147,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
                 }}
               />
             ) : (
-              <span style={{ fontSize: '2rem' }}>📷</span>
+              <Icon icon={Camera} size={32} color="secondary" decorative />
             )}
           </div>
         )}
@@ -160,14 +162,14 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
             alignItems: 'center',
             gap: '0.5rem'
           }}>
-            🐟 {record.fishSpecies}
+            <Icon icon={Fish} size={20} decorative /> {record.fishSpecies}
           </h3>
           <p style={{
             margin: '0',
             fontSize: '0.875rem',
             color: '#6c757d'
           }}>
-            📅 {formatDate(record.date)}
+            <Icon icon={Calendar} size={14} decorative /> {formatDate(record.date)}
           </p>
         </div>
 
@@ -182,7 +184,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
           minWidth: 'fit-content',
           alignSelf: 'flex-start'
         }}>
-          📏 {formatSize(record.size)}
+          <Icon icon={Ruler} size={14} decorative /> {formatSize(record.size)}
         </div>
       </div>
 
@@ -195,7 +197,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
           color: '#333',
           marginBottom: '0.25rem'
         }}>
-          🗺️ {formatLocation(record.location)}
+          <Icon icon={Map} size={14} decorative /> {formatLocation(record.location)}
         </div>
         {record.coordinates && (
           <LocationDisplay
@@ -222,7 +224,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
             }}
             title="Googleマップで表示"
           >
-            🗺️ 地図
+            <Icon icon={Map} size={12} decorative /> 地図
           </a>
         )}
       </div>
@@ -249,7 +251,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
             WebkitLineClamp: 2,
             WebkitBoxOrient: 'vertical'
           }}>
-            💭 {record.notes}
+            <Icon icon={MessageCircle} size={14} decorative /> {record.notes}
           </p>
         </div>
       )}
@@ -296,7 +298,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
               title="編集"
               aria-label={`${record.fishSpecies}の記録を編集`}
             >
-              ✏️ 編集
+              <Icon icon={Edit} size={12} decorative /> 編集
             </button>
 
             <button
@@ -317,7 +319,7 @@ export const FishingRecordCard: React.FC<FishingRecordCardProps> = ({
               title="削除"
               aria-label={`${record.fishSpecies}の記録を削除`}
             >
-              🗑️ 削除
+              <Icon icon={Trash2} size={12} decorative /> 削除
             </button>
           </div>
         )}

--- a/src/components/FishingRecordList.tsx
+++ b/src/components/FishingRecordList.tsx
@@ -1,6 +1,6 @@
 // 釣果記録一覧コンポーネント
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, type ReactNode } from 'react';
 import { TestIds } from '../constants/testIds';
 import { FishingRecordCard } from './FishingRecordCard';
 import { AdvancedSearchFilter } from './AdvancedSearchFilter';
@@ -9,6 +9,23 @@ import { DataExportModal } from './DataExportModal';
 import { DataImportModal } from './DataImportModal';
 import { StatisticsDashboard } from './StatisticsDashboard';
 import { useAdvancedSearch } from '../hooks/useAdvancedSearch';
+import { Icon } from './ui/Icon';
+import {
+  Calendar,
+  Fish,
+  MapPin,
+  Ruler,
+  RefreshCw,
+  Anchor,
+  Plus,
+  BarChart3,
+  Search,
+  Upload,
+  Download,
+  AlertTriangle,
+  FileText,
+  Scroll,
+} from 'lucide-react';
 import type { FishingRecord } from '../types';
 
 interface FishingRecordListProps {
@@ -31,15 +48,15 @@ interface FishingRecordListProps {
 type SortOption = {
   key: keyof FishingRecord;
   label: string;
-  icon: string;
+  icon: ReactNode;
 };
 
 const sortOptions: SortOption[] = [
-  { key: 'date', label: '日付', icon: '📅' },
-  { key: 'fishSpecies', label: '魚種', icon: '🐟' },
-  { key: 'location', label: '場所', icon: '📍' },
-  { key: 'size', label: 'サイズ', icon: '📏' },
-  { key: 'updatedAt', label: '更新日時', icon: '🔄' }
+  { key: 'date', label: '日付', icon: <Icon icon={Calendar} size={14} decorative /> },
+  { key: 'fishSpecies', label: '魚種', icon: <Icon icon={Fish} size={14} decorative /> },
+  { key: 'location', label: '場所', icon: <Icon icon={MapPin} size={14} decorative /> },
+  { key: 'size', label: 'サイズ', icon: <Icon icon={Ruler} size={14} decorative /> },
+  { key: 'updatedAt', label: '更新日時', icon: <Icon icon={RefreshCw} size={14} decorative /> }
 ];
 
 export const FishingRecordList: React.FC<FishingRecordListProps> = ({
@@ -195,7 +212,8 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             fontSize: 'clamp(1.5rem, 4vw, 2rem)',
             color: '#333'
           }}>
-            🎣 釣果記録一覧
+            <Icon icon={Anchor} size="md" decorative />
+            釣果記録一覧
           </h2>
           <button
             data-testid={TestIds.ADD_RECORD_BUTTON}
@@ -214,7 +232,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
               whiteSpace: 'nowrap'
             }}
           >
-            ➕ 新規記録
+            <Icon icon={Plus} size="sm" decorative /> 新規記録
           </button>
         </div>
 
@@ -231,7 +249,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             backgroundColor: '#f8f9fa',
             borderRadius: '20px'
           }}>
-            📊 {filteredRecords.length}件
+            <Icon icon={BarChart3} size={14} decorative /> {filteredRecords.length}件
             {!isFiltersEmpty && ` / ${records.length}件中`}
           </span>
 
@@ -264,7 +282,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             aria-expanded={showFilters}
             aria-label="基本検索の表示切り替え"
           >
-            🔍 {showFilters ? '隠す' : '基本検索'}
+            <Icon icon={Search} size={14} decorative /> {showFilters ? '隠す' : '基本検索'}
           </button>
 
           <button
@@ -285,7 +303,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             aria-expanded={showAdvancedSearch}
             aria-label="高度な検索の表示切り替え"
           >
-            🔍+ {showAdvancedSearch ? '隠す' : '高度な検索'}
+            <Icon icon={Search} size={14} decorative /> {showAdvancedSearch ? '隠す' : '高度な検索'}
             {activeFilterCount > 0 && (
               <span style={{
                 position: 'absolute',
@@ -322,7 +340,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             }}
             aria-label="データエクスポート"
           >
-            📤 エクスポート
+            <Icon icon={Upload} size={14} decorative /> エクスポート
           </button>
 
           <button
@@ -341,7 +359,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             }}
             aria-label="データインポート"
           >
-            📥 インポート
+            <Icon icon={Download} size={14} decorative /> インポート
           </button>
 
           <button
@@ -362,7 +380,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             }}
             aria-label="統計ダッシュボード"
           >
-            📊 統計
+            <Icon icon={BarChart3} size={14} decorative /> 統計
           </button>
         </div>
       </div>
@@ -387,7 +405,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
                 fontSize: '0.875rem'
               }}
             >
-              🔍 検索
+              <Icon icon={Search} size={14} decorative /> 検索
             </label>
             <input
               id="search-input"
@@ -413,7 +431,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
               fontWeight: 'bold',
               fontSize: '0.875rem'
             }}>
-              📋 並び順
+              <Icon icon={FileText} size={14} decorative /> 並び順
             </label>
             <div style={{
               display: 'flex',
@@ -488,7 +506,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             fontWeight: 'bold',
             color: '#333'
           }}>
-            📊 検索結果の統計
+            <Icon icon={BarChart3} size={14} decorative /> 検索結果の統計
           </h4>
           <div style={{
             display: 'grid',
@@ -524,7 +542,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
           borderRadius: '8px',
           marginBottom: '1.5rem'
         }}>
-          ⚠️ {error}
+          <Icon icon={AlertTriangle} size={14} decorative /> {error}
         </div>
       )}
 
@@ -542,7 +560,9 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
             padding: '3rem 1rem',
             color: '#6c757d'
           }}>
-            <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>🎣</div>
+            <div style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'center' }}>
+              <Icon icon={Anchor} size={48} color="secondary" decorative />
+            </div>
             <h3 style={{ margin: '0 0 0.5rem 0' }}>記録がありません</h3>
             <p style={{ margin: 0, fontSize: '0.875rem' }}>
               {searchQuery ? '検索条件に一致する記録が見つかりませんでした' : 'まだ釣果記録がありません'}
@@ -597,7 +617,7 @@ export const FishingRecordList: React.FC<FishingRecordListProps> = ({
               </>
             ) : (
               <>
-                📜 もっと見る
+                <Icon icon={Scroll} size={14} decorative /> もっと見る
               </>
             )}
           </button>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,9 +1,36 @@
 // 設定・カスタマイズモーダルコンポーネント
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, type ReactNode } from 'react';
 import { useAppStore, selectSettings, selectActions } from '../stores/app-store';
 import type { AppSettings } from '../types';
 import { logger } from '../lib/errors/logger';
+import { Icon } from './ui/Icon';
+import {
+  Settings,
+  Palette,
+  Save,
+  Lock,
+  Wrench,
+  Globe,
+  Calendar,
+  Ruler,
+  Target,
+  Moon,
+  Sun,
+  RefreshCw,
+  Eye,
+  CalendarDays,
+  Camera,
+  MapPin,
+  Bell,
+  FileText,
+  FolderOpen,
+  FlaskConical,
+  Info,
+  Loader2,
+  Trash2,
+  AlertTriangle,
+} from 'lucide-react';
 
 interface SettingsModalProps {
   isVisible: boolean;
@@ -125,12 +152,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   if (!isVisible) return null;
 
   type TabId = 'general' | 'display' | 'data' | 'privacy' | 'advanced';
-  const tabs: Array<{ id: TabId; label: string; icon: string }> = [
-    { id: 'general', label: '一般', icon: '⚙️' },
-    { id: 'display', label: '表示', icon: '🎨' },
-    { id: 'data', label: 'データ', icon: '💾' },
-    { id: 'privacy', label: 'プライバシー', icon: '🔒' },
-    { id: 'advanced', label: '詳細', icon: '🔧' }
+  const tabs: Array<{ id: TabId; label: string; icon: ReactNode }> = [
+    { id: 'general', label: '一般', icon: <Icon icon={Settings} size="sm" decorative /> },
+    { id: 'display', label: '表示', icon: <Icon icon={Palette} size="sm" decorative /> },
+    { id: 'data', label: 'データ', icon: <Icon icon={Save} size="sm" decorative /> },
+    { id: 'privacy', label: 'プライバシー', icon: <Icon icon={Lock} size="sm" decorative /> },
+    { id: 'advanced', label: '詳細', icon: <Icon icon={Wrench} size="sm" decorative /> }
   ];
 
   return (
@@ -169,9 +196,13 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             margin: 0,
             fontSize: '1.5rem',
             fontWeight: 'bold',
-            color: '#333'
+            color: '#333',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
           }}>
-            ⚙️ 設定
+            <Icon icon={Settings} size="md" decorative />
+            設定
           </h2>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             {hasChanges && (
@@ -310,7 +341,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
               gap: '0.5rem'
             }}
           >
-            {isSaving ? '⏳ 保存中...' : '💾 保存'}
+            {isSaving ? <><Icon icon={Loader2} size="sm" className="animate-spin" decorative /> 保存中...</> : <><Icon icon={Save} size="sm" decorative /> 保存</>}
           </button>
         </div>
       </div>
@@ -324,11 +355,14 @@ const GeneralTab: React.FC<{
   onSettingChange: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
 }> = ({ settings, onSettingChange }) => (
   <div>
-    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333' }}>⚙️ 一般設定</h3>
+    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Icon icon={Settings} size="sm" decorative />
+      一般設定
+    </h3>
 
     <div style={{ display: 'grid', gap: '1.5rem' }}>
       {/* 言語設定 */}
-      <SettingGroup title="🌐 言語" description="アプリの表示言語を選択">
+      <SettingGroup title="言語" titleIcon={<Icon icon={Globe} size="sm" decorative />} description="アプリの表示言語を選択">
         <select
           value={settings.language}
           onChange={(e) => onSettingChange('language', e.target.value as 'ja' | 'en')}
@@ -345,7 +379,7 @@ const GeneralTab: React.FC<{
       </SettingGroup>
 
       {/* 日付形式 */}
-      <SettingGroup title="📅 日付形式" description="日付の表示形式を選択">
+      <SettingGroup title="日付形式" titleIcon={<Icon icon={Calendar} size="sm" decorative />} description="日付の表示形式を選択">
         <select
           value={settings.dateFormat}
           onChange={(e) => onSettingChange('dateFormat', e.target.value as 'YYYY/MM/DD' | 'DD/MM/YYYY' | 'MM/DD/YYYY')}
@@ -364,7 +398,7 @@ const GeneralTab: React.FC<{
       </SettingGroup>
 
       {/* 単位設定 */}
-      <SettingGroup title="📏 単位設定" description="測定単位を選択">
+      <SettingGroup title="単位設定" titleIcon={<Icon icon={Ruler} size="sm" decorative />} description="測定単位を選択">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <label style={{ minWidth: '80px', fontSize: '0.9rem' }}>気温:</label>
@@ -402,7 +436,7 @@ const GeneralTab: React.FC<{
       </SettingGroup>
 
       {/* デフォルト値 */}
-      <SettingGroup title="🎯 デフォルト値" description="新規記録作成時のデフォルト値">
+      <SettingGroup title="デフォルト値" titleIcon={<Icon icon={Target} size="sm" decorative />} description="新規記録作成時のデフォルト値">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <div>
             <label style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.9rem' }}>
@@ -452,16 +486,19 @@ const DisplayTab: React.FC<{
   onSettingChange: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
 }> = ({ settings, onSettingChange }) => (
   <div>
-    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333' }}>🎨 表示設定</h3>
+    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Icon icon={Palette} size="sm" decorative />
+      表示設定
+    </h3>
 
     <div style={{ display: 'grid', gap: '1.5rem' }}>
       {/* テーマ設定 */}
-      <SettingGroup title="🌙 テーマ" description="アプリの外観テーマを選択">
+      <SettingGroup title="テーマ" titleIcon={<Icon icon={Moon} size="sm" decorative />} description="アプリの外観テーマを選択">
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           {[
-            { value: 'light', label: 'ライト', icon: '☀️' },
-            { value: 'dark', label: 'ダーク', icon: '🌙' },
-            { value: 'auto', label: '自動', icon: '🔄' }
+            { value: 'light', label: 'ライト', icon: <Icon icon={Sun} size={14} decorative /> },
+            { value: 'dark', label: 'ダーク', icon: <Icon icon={Moon} size={14} decorative /> },
+            { value: 'auto', label: '自動', icon: <Icon icon={RefreshCw} size={14} decorative /> }
           ].map(theme => (
             <button
               key={theme.value}
@@ -486,7 +523,7 @@ const DisplayTab: React.FC<{
       </SettingGroup>
 
       {/* 表示オプション */}
-      <SettingGroup title="👁️ 表示オプション" description="画面表示に関する設定">
+      <SettingGroup title="表示オプション" titleIcon={<Icon icon={Eye} size="sm" decorative />} description="画面表示に関する設定">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <ToggleSetting
             label="コンパクト表示"
@@ -518,11 +555,14 @@ const DataTab: React.FC<{
   onSettingChange: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
 }> = ({ settings, onSettingChange }) => (
   <div>
-    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333' }}>💾 データ設定</h3>
+    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Icon icon={Save} size="sm" decorative />
+      データ設定
+    </h3>
 
     <div style={{ display: 'grid', gap: '1.5rem' }}>
       {/* 自動保存 */}
-      <SettingGroup title="💾 自動保存" description="データの自動保存設定">
+      <SettingGroup title="自動保存" titleIcon={<Icon icon={Save} size="sm" decorative />} description="データの自動保存設定">
         <ToggleSetting
           label="自動保存を有効にする"
           description="入力内容を自動的に保存"
@@ -532,7 +572,7 @@ const DataTab: React.FC<{
       </SettingGroup>
 
       {/* エクスポート形式 */}
-      <SettingGroup title="📤 エクスポート形式" description="デフォルトのエクスポート形式">
+      <SettingGroup title="エクスポート形式" titleIcon={<Icon icon={FileText} size="sm" decorative />} description="デフォルトのエクスポート形式">
         <select
           value={settings.exportFormat}
           onChange={(e) => onSettingChange('exportFormat', e.target.value as 'json' | 'csv')}
@@ -549,7 +589,7 @@ const DataTab: React.FC<{
       </SettingGroup>
 
       {/* データ保持期間 */}
-      <SettingGroup title="🗓️ データ保持期間" description="データを保持する期間（日数）">
+      <SettingGroup title="データ保持期間" titleIcon={<Icon icon={CalendarDays} size="sm" decorative />} description="データを保持する期間（日数）">
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <input
             type="number"
@@ -573,7 +613,7 @@ const DataTab: React.FC<{
       </SettingGroup>
 
       {/* 写真設定 */}
-      <SettingGroup title="📷 写真設定" description="写真の保存に関する設定">
+      <SettingGroup title="写真設定" titleIcon={<Icon icon={Camera} size="sm" decorative />} description="写真の保存に関する設定">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <div>
             <label style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.9rem' }}>
@@ -626,11 +666,14 @@ const PrivacyTab: React.FC<{
   onSettingChange: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
 }> = ({ settings, onSettingChange }) => (
   <div>
-    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333' }}>🔒 プライバシー設定</h3>
+    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Icon icon={Lock} size="sm" decorative />
+      プライバシー設定
+    </h3>
 
     <div style={{ display: 'grid', gap: '1.5rem' }}>
       {/* 位置情報 */}
-      <SettingGroup title="📍 位置情報" description="GPS位置情報の利用設定">
+      <SettingGroup title="位置情報" titleIcon={<Icon icon={MapPin} size="sm" decorative />} description="GPS位置情報の利用設定">
         <ToggleSetting
           label="自動位置取得を有効にする"
           description="記録作成時に現在位置を自動取得"
@@ -640,7 +683,7 @@ const PrivacyTab: React.FC<{
       </SettingGroup>
 
       {/* 通知設定 */}
-      <SettingGroup title="🔔 通知" description="アプリからの通知設定">
+      <SettingGroup title="通知" titleIcon={<Icon icon={Bell} size="sm" decorative />} description="アプリからの通知設定">
         <ToggleSetting
           label="通知を有効にする"
           description="重要な更新やリマインダーを受け取る"
@@ -656,7 +699,10 @@ const PrivacyTab: React.FC<{
         borderRadius: '6px',
         border: '1px solid #90caf9'
       }}>
-        <h4 style={{ margin: '0 0 0.5rem 0', color: '#1976d2' }}>📋 データの取り扱いについて</h4>
+        <h4 style={{ margin: '0 0 0.5rem 0', color: '#1976d2', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <Icon icon={FileText} size="sm" decorative />
+          データの取り扱いについて
+        </h4>
         <ul style={{ margin: 0, paddingLeft: '1.5rem', fontSize: '0.85rem', color: '#1976d2' }}>
           <li>すべてのデータはお使いのデバイス内にのみ保存されます</li>
           <li>外部サーバーにデータが送信されることはありません</li>
@@ -676,11 +722,14 @@ const AdvancedTab: React.FC<{
   onReset: () => void;
 }> = ({ onClearData, onReset }) => (
   <div>
-    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333' }}>🔧 詳細設定</h3>
+    <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Icon icon={Wrench} size="sm" decorative />
+      詳細設定
+    </h3>
 
     <div style={{ display: 'grid', gap: '1.5rem' }}>
       {/* アプリ情報 */}
-      <SettingGroup title="ℹ️ アプリ情報" description="アプリケーションの詳細情報">
+      <SettingGroup title="アプリ情報" titleIcon={<Icon icon={Info} size="sm" decorative />} description="アプリケーションの詳細情報">
         <div style={{
           padding: '1rem',
           backgroundColor: '#f8f9fa',
@@ -700,7 +749,7 @@ const AdvancedTab: React.FC<{
       </SettingGroup>
 
       {/* データ管理 */}
-      <SettingGroup title="🗂️ データ管理" description="データの管理とメンテナンス">
+      <SettingGroup title="データ管理" titleIcon={<Icon icon={FolderOpen} size="sm" decorative />} description="データの管理とメンテナンス">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <button
             onClick={onReset}
@@ -717,7 +766,7 @@ const AdvancedTab: React.FC<{
               gap: '0.5rem'
             }}
           >
-            🔄 設定をリセット
+            <Icon icon={RefreshCw} size="sm" decorative /> 設定をリセット
           </button>
           <button
             onClick={onClearData}
@@ -734,13 +783,13 @@ const AdvancedTab: React.FC<{
               gap: '0.5rem'
             }}
           >
-            🗑️ すべてのデータを削除
+            <Icon icon={Trash2} size="sm" decorative /> すべてのデータを削除
           </button>
         </div>
       </SettingGroup>
 
       {/* 実験的機能 */}
-      <SettingGroup title="🧪 実験的機能" description="開発中の新機能（注意して使用）">
+      <SettingGroup title="実験的機能" titleIcon={<Icon icon={FlaskConical} size="sm" decorative />} description="開発中の新機能（注意して使用）">
         <div style={{ display: 'grid', gap: '0.75rem' }}>
           <div style={{
             padding: '1rem',
@@ -750,7 +799,7 @@ const AdvancedTab: React.FC<{
             fontSize: '0.85rem',
             color: '#856404'
           }}>
-            <strong>⚠️ 注意:</strong> 実験的機能は予期しない動作をする可能性があります。
+            <strong style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}><Icon icon={AlertTriangle} size={14} decorative /> 注意:</strong> 実験的機能は予期しない動作をする可能性があります。
             重要なデータは事前にバックアップを取ることをお勧めします。
           </div>
         </div>
@@ -762,16 +811,18 @@ const AdvancedTab: React.FC<{
 // 設定グループコンポーネント
 const SettingGroup: React.FC<{
   title: string;
+  titleIcon?: ReactNode;
   description: string;
   children: React.ReactNode;
-}> = ({ title, description, children }) => (
+}> = ({ title, titleIcon, description, children }) => (
   <div style={{
     padding: '1rem',
     backgroundColor: 'white',
     borderRadius: '8px',
     border: '1px solid #dee2e6'
   }}>
-    <h4 style={{ margin: '0 0 0.25rem 0', fontSize: '1rem', color: '#333' }}>
+    <h4 style={{ margin: '0 0 0.25rem 0', fontSize: '1rem', color: '#333', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      {titleIcon}
       {title}
     </h4>
     <p style={{ margin: '0 0 1rem 0', fontSize: '0.85rem', color: '#666' }}>

--- a/src/components/chart/TrendChart.tsx
+++ b/src/components/chart/TrendChart.tsx
@@ -3,7 +3,7 @@
  * 月別の釣果数推移を表示するシンプルなチャート
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
   LineChart,
   Line,
@@ -15,6 +15,8 @@ import {
   CartesianGrid,
 } from 'recharts';
 import { colors } from '../../theme/colors';
+import { Icon } from '../ui/Icon';
+import { Fish } from 'lucide-react';
 
 export interface TrendChartData {
   month: string;      // '10月' または '2024/10'
@@ -29,6 +31,7 @@ export interface TrendChartProps {
   height?: number;
   showGrid?: boolean;
   title?: string;
+  titleIcon?: ReactNode;
   color?: string;
 }
 
@@ -60,8 +63,12 @@ const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<
           fontSize: '0.875rem',
           color: colors.primary[600],
           fontWeight: '500',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
         }}>
-          🐟 {payload[0].value ?? payload[0].payload.count}件の記録
+          <Icon icon={Fish} size={14} decorative />
+          {payload[0].value ?? payload[0].payload.count}件の記録
         </p>
       </div>
     );
@@ -79,6 +86,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({
   height = 250,
   showGrid = true,
   title,
+  titleIcon,
   color = colors.primary[500],
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -125,7 +133,11 @@ export const TrendChart: React.FC<TrendChartProps> = ({
           fontSize: '1rem',
           fontWeight: '600',
           color: colors.text.primary,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
         }}>
+          {titleIcon}
           {title}
         </h3>
       )}


### PR DESCRIPTION
## Summary
- Phase 2: コアUIコンポーネントの絵文字をLucide SVGアイコンに置き換え
- App.tsx: アプリヘッダー、タブ、デバッグセクションのアイコン更新
- ModernApp.tsx: 検索、フィルター、記録カード、トレンドチャートのアイコン更新
- SettingsModal.tsx: 全タブと設定グループのアイコン更新
- FishingRecordList.tsx: リストヘッダー、フィルター、ソートオプションのアイコン更新
- FishingRecordCard.tsx: カードアイコン（魚種、場所、日付等）の更新
- TrendChart.tsx: titleIconプロパティのサポート追加

## Test plan
- [x] 型チェックが通ること（`npm run typecheck`）
- [x] 全テストが通ること（`npm run test:fast` - 66ファイル、1493テストパス）
- [x] lintエラーがないこと（`npm run lint` - 0エラー）
- [ ] ビルドが成功すること
- [ ] UIで各アイコンが正しく表示されること

## Related Issues
- Parent Epic: #207
- Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)