### PR TITLE
feat(ui): Phase 1 - エラーコンポーネントの絵文字をLucideアイコンに置き換え

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 // エラーバウンダリコンポーネント
 
 import React, { Component, type ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { errorManager } from '../lib/errors/ErrorManager';
 import { AppError, ErrorSeverity, ErrorCategory } from '../lib/errors/ErrorTypes';
 import { TestIds } from '../constants/testIds';
@@ -84,7 +85,20 @@ export class ErrorBoundary extends Component<Props, State> {
             margin: '1rem'
           }}
         >
-          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>⚠️</div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '64px',
+              height: '64px',
+              borderRadius: '50%',
+              backgroundColor: 'rgba(239, 68, 68, 0.1)',
+              margin: '0 auto 1rem auto'
+            }}
+          >
+            <AlertTriangle size={48} color="#EF4444" aria-hidden="true" />
+          </div>
           <h2 style={{ color: '#dc3545', marginBottom: '1rem' }}>
             エラーが発生しました
           </h2>

--- a/src/components/RetryableAction.tsx
+++ b/src/components/RetryableAction.tsx
@@ -1,6 +1,7 @@
 // リトライ可能アクションコンポーネント
 
 import { useState } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { RetryService } from '../lib/retry-service';
 
 export interface RetryableActionProps<T = unknown> {
@@ -119,7 +120,7 @@ export const RetryableAction = <T = unknown,>({
     if (hasError) {
       return (
         <>
-          🔄 再試行 {retryCount > 0 && `(${retryCount}回目)`}
+          <RefreshCw size={16} aria-hidden="true" /> 再試行 {retryCount > 0 && `(${retryCount}回目)`}
         </>
       );
     }
@@ -158,7 +159,7 @@ export const RetryableAction = <T = unknown,>({
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
-            <span>⚠️</span>
+            <AlertTriangle size={20} color="#F59E0B" aria-hidden="true" />
             <strong>エラーが発生しました</strong>
           </div>
           <p style={{ margin: 0, fontSize: '0.9rem' }}>

--- a/src/components/errors/ErrorModal.tsx
+++ b/src/components/errors/ErrorModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { Info, AlertTriangle, XCircle, AlertOctagon, X } from 'lucide-react';
 import { AppError, ErrorSeverity } from '../../lib/errors/ErrorTypes';
 
 export interface ErrorModalProps {
@@ -22,21 +23,15 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
   const message = isAppError ? error.userMessage : error.message;
   const code = isAppError ? error.code : 'UNKNOWN_ERROR';
 
-  // アイコンの選択
-  const getIcon = () => {
-    switch (severity) {
-      case ErrorSeverity.INFO:
-        return 'ℹ️';
-      case ErrorSeverity.WARNING:
-        return '⚠️';
-      case ErrorSeverity.ERROR:
-        return '❌';
-      case ErrorSeverity.CRITICAL:
-        return '🚨';
-      default:
-        return '❌';
-    }
+  // アイコンマップの定義
+  const iconConfig = {
+    [ErrorSeverity.INFO]: { Icon: Info, color: '#3B82F6' },
+    [ErrorSeverity.WARNING]: { Icon: AlertTriangle, color: '#F59E0B' },
+    [ErrorSeverity.ERROR]: { Icon: XCircle, color: '#EF4444' },
+    [ErrorSeverity.CRITICAL]: { Icon: AlertOctagon, color: '#DC2626' },
   };
+
+  const { Icon: StatusIcon, color: iconColor } = iconConfig[severity] || iconConfig[ErrorSeverity.ERROR];
 
   // タイトル色の選択
   const getTitleColor = () => {
@@ -96,7 +91,9 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
               gap: '1rem'
             }}
           >
-            <div style={{ fontSize: '2rem' }}>{getIcon()}</div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <StatusIcon size={24} color={iconColor} aria-hidden="true" />
+            </div>
             <div style={{ flex: 1 }}>
               <h2
                 style={{
@@ -129,7 +126,6 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
                 backgroundColor: 'transparent',
                 border: 'none',
                 cursor: 'pointer',
-                fontSize: '1.5rem',
                 color: '#6c757d',
                 padding: '0',
                 width: '32px',
@@ -140,7 +136,7 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
               }}
               aria-label="閉じる"
             >
-              ✕
+              <X size={20} aria-hidden="true" />
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- ErrorModal.tsx: 絵文字（ℹ️⚠️❌🚨✕）をLucideアイコン（Info, AlertTriangle, XCircle, AlertOctagon, X）に置き換え
- ErrorBoundary.tsx: 絵文字（⚠️）をAlertTriangleアイコン（48px、円形背景付き）に置き換え
- RetryableAction.tsx: 絵文字（🔄⚠️）をLucideアイコン（RefreshCw, AlertTriangle）に置き換え
- 全アイコンに `aria-hidden="true"` を設定しアクセシビリティ対応

## Test plan
- [x] ビルドが成功
- [x] ErrorBoundaryの既存テスト（6件）がパス
- [ ] ダークモードでの視認性確認（手動）

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)