### PR TITLE
feat(ui): Phase 2 - モーダル/フォームコンポーネントの絵文字をLucideアイコンに置き換え

### DIFF
--- a/src/components/DataExportModal.tsx
+++ b/src/components/DataExportModal.tsx
@@ -1,6 +1,7 @@
 // データエクスポートモーダルコンポーネント
 
 import React, { useState, useCallback } from 'react';
+import { Upload, X, FileText, FileSpreadsheet, Calendar, Image, CheckCircle, XCircle, Loader } from 'lucide-react';
 import { exportImportService } from '../lib/export-import-service';
 import type { FishingRecord } from '../types';
 
@@ -127,22 +128,29 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
             margin: 0,
             fontSize: '1.5rem',
             fontWeight: 'bold',
-            color: '#333'
+            color: '#333',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
           }}>
-            📤 データエクスポート
+            <Upload size={24} color="#6366F1" aria-hidden="true" />
+            データエクスポート
           </h2>
           <button
             onClick={onClose}
+            aria-label="閉じる"
             style={{
               backgroundColor: 'transparent',
               border: 'none',
               cursor: 'pointer',
-              fontSize: '1.5rem',
               color: '#6c757d',
-              padding: '0.25rem'
+              padding: '0.25rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
             }}
           >
-            ✕
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
 
@@ -174,7 +182,9 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
                 checked={exportFormat === 'json'}
                 onChange={(e) => setExportFormat(e.target.value as 'json' | 'csv')}
               />
-              <span>📄 JSON (全データ)</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <FileText size={18} color="#6366F1" aria-hidden="true" /> JSON (全データ)
+              </span>
             </label>
             <label style={{
               display: 'flex',
@@ -188,7 +198,9 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
                 checked={exportFormat === 'csv'}
                 onChange={(e) => setExportFormat(e.target.value as 'json' | 'csv')}
               />
-              <span>📊 CSV (記録のみ)</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <FileSpreadsheet size={18} color="#6366F1" aria-hidden="true" /> CSV (記録のみ)
+              </span>
             </label>
           </div>
         </div>
@@ -202,7 +214,9 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
             fontSize: '0.9rem',
             color: '#333'
           }}>
-            📅 日付範囲（オプション）
+            <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <Calendar size={20} color="#8B5CF6" aria-hidden="true" /> 日付範囲（オプション）
+            </span>
           </label>
           <div style={{
             display: 'grid',
@@ -263,7 +277,9 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
                   height: '18px'
                 }}
               />
-              <span style={{ fontSize: '0.9rem' }}>📷 写真データを含める</span>
+              <span style={{ fontSize: '0.9rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <Image size={18} color="#6B7280" aria-hidden="true" /> 写真データを含める
+              </span>
             </label>
           </div>
         )}
@@ -307,7 +323,13 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
             color: exportStatus.type === 'success' ? '#155724' : '#721c24',
             border: `1px solid ${exportStatus.type === 'success' ? '#c3e6cb' : '#f5c6cb'}`
           }}>
-            {exportStatus.type === 'success' ? '✅' : '❌'} {exportStatus.message}
+            <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              {exportStatus.type === 'success'
+                ? <CheckCircle size={20} color="#10B981" aria-hidden="true" />
+                : <XCircle size={20} color="#EF4444" aria-hidden="true" />
+              }
+              {exportStatus.message}
+            </span>
           </div>
         )}
 
@@ -349,7 +371,15 @@ export const DataExportModal: React.FC<DataExportModalProps> = ({
               gap: '0.5rem'
             }}
           >
-            {isExporting ? '⏳ エクスポート中...' : '📤 エクスポート'}
+            {isExporting ? (
+              <>
+                <Loader size={18} className="animate-spin" aria-hidden="true" /> エクスポート中...
+              </>
+            ) : (
+              <>
+                <Upload size={18} aria-hidden="true" /> エクスポート
+              </>
+            )}
           </button>
         </div>
       </div>

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -1,6 +1,7 @@
 // データインポートモーダルコンポーネント
 
 import React, { useState, useCallback, useRef } from 'react';
+import { Download, X, Lightbulb, FileText, Paperclip, CheckCircle, XCircle, AlertTriangle, Loader } from 'lucide-react';
 import { exportImportService } from '../lib/export-import-service';
 import type { ImportResult } from '../types';
 
@@ -179,22 +180,29 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
             margin: 0,
             fontSize: '1.5rem',
             fontWeight: 'bold',
-            color: '#333'
+            color: '#333',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
           }}>
-            📥 データインポート
+            <Download size={24} color="#6366F1" aria-hidden="true" />
+            データインポート
           </h2>
           <button
             onClick={handleClose}
+            aria-label="閉じる"
             style={{
               backgroundColor: 'transparent',
               border: 'none',
               cursor: 'pointer',
-              fontSize: '1.5rem',
               color: '#6c757d',
-              padding: '0.25rem'
+              padding: '0.25rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
             }}
           >
-            ✕
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
 
@@ -210,9 +218,13 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
           <h4 style={{
             margin: '0 0 0.5rem 0',
             fontSize: '0.9rem',
-            fontWeight: 'bold'
+            fontWeight: 'bold',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
           }}>
-            💡 インポート可能なファイル形式
+            <Lightbulb size={18} color="#1976d2" aria-hidden="true" />
+            インポート可能なファイル形式
           </h4>
           <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
             <li>JSON形式: 全データ（記録、写真、設定）</li>
@@ -247,7 +259,9 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
 
           {selectedFile ? (
             <div>
-              <div style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>📁</div>
+              <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center' }}>
+                <FileText size={40} color="#28a745" aria-hidden="true" />
+              </div>
               <div style={{
                 fontWeight: 'bold',
                 fontSize: '1rem',
@@ -265,7 +279,9 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
             </div>
           ) : (
             <div>
-              <div style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>📎</div>
+              <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center' }}>
+                <Paperclip size={40} color="#6c757d" aria-hidden="true" />
+              </div>
               <div style={{
                 fontSize: '1rem',
                 color: '#333',
@@ -298,7 +314,12 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
               fontWeight: 'bold',
               color: importResult.success ? '#155724' : '#721c24'
             }}>
-              {importResult.success ? '✅ インポート完了' : '❌ インポート失敗'}
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {importResult.success
+                  ? <><CheckCircle size={20} color="#10B981" aria-hidden="true" /> インポート完了</>
+                  : <><XCircle size={20} color="#EF4444" aria-hidden="true" /> インポート失敗</>
+                }
+              </span>
             </h4>
 
             {importResult.success && (
@@ -347,7 +368,10 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
           color: '#856404',
           border: '1px solid #ffeaa7'
         }}>
-          <strong>⚠️ 注意:</strong> インポートにより既存のデータが上書きされる場合があります。
+          <span style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+            <AlertTriangle size={18} color="#F59E0B" aria-hidden="true" style={{ flexShrink: 0, marginTop: '2px' }} />
+            <span><strong>注意:</strong> インポートにより既存のデータが上書きされる場合があります。</span>
+          </span>
           重要なデータは事前にエクスポートしてバックアップを取ることをお勧めします。
         </div>
 
@@ -390,7 +414,15 @@ export const DataImportModal: React.FC<DataImportModalProps> = ({
                 gap: '0.5rem'
               }}
             >
-              {isImporting ? '⏳ インポート中...' : '📥 インポート'}
+              {isImporting ? (
+                <>
+                  <Loader size={18} className="animate-spin" aria-hidden="true" /> インポート中...
+                </>
+              ) : (
+                <>
+                  <Download size={18} aria-hidden="true" /> インポート
+                </>
+              )}
             </button>
           )}
         </div>

--- a/src/components/FishSpeciesAutocomplete.css
+++ b/src/components/FishSpeciesAutocomplete.css
@@ -116,8 +116,14 @@
 }
 
 .fish-species-autocomplete .error-message::before {
-  content: '⚠';
-  font-size: 1rem;
+  content: '';
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23F59E0B' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  flex-shrink: 0;
 }
 
 @keyframes slideDown {
@@ -292,10 +298,14 @@
 }
 
 .fish-species-autocomplete .no-results::before {
-  content: '🔍';
+  content: '';
   display: block;
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  margin: 0 auto 0.5rem auto;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%236B7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
   opacity: 0.5;
 }
 

--- a/src/components/GPSLocationInput.tsx
+++ b/src/components/GPSLocationInput.tsx
@@ -1,6 +1,7 @@
 // GPS位置取得・手動入力コンポーネント
 
 import React, { useState, useCallback } from 'react';
+import { MapPin, Pencil, Trash2, ExternalLink, AlertTriangle } from 'lucide-react';
 import { LocationDisplay } from './LocationDisplay';
 import { useToastStore } from '../stores/toast-store';
 import { TestIds } from '../constants/testIds';
@@ -194,7 +195,7 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
                 </>
               ) : (
                 <>
-                  📍 現在位置を取得
+                  <MapPin size={18} aria-hidden="true" /> 現在位置を取得
                 </>
               )}
             </button>
@@ -203,6 +204,7 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
               type="button"
               onClick={handleToggleManualMode}
               disabled={disabled}
+              aria-label="手動入力"
               style={{
                 padding: '0.75rem 1rem',
                 backgroundColor: '#6c757d',
@@ -210,10 +212,13 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
                 border: 'none',
                 borderRadius: '4px',
                 cursor: disabled ? 'not-allowed' : 'pointer',
-                marginRight: '0.5rem'
+                marginRight: '0.5rem',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem'
               }}
             >
-              ✏️ 手動入力
+              <Pencil size={16} aria-hidden="true" /> 手動入力
             </button>
 
             {value && (
@@ -221,16 +226,20 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
                 type="button"
                 onClick={handleClearLocation}
                 disabled={disabled}
+                aria-label="位置情報をクリア"
                 style={{
                   padding: '0.75rem 1rem',
                   backgroundColor: '#dc3545',
                   color: 'white',
                   border: 'none',
                   borderRadius: '4px',
-                  cursor: disabled ? 'not-allowed' : 'pointer'
+                  cursor: disabled ? 'not-allowed' : 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem'
                 }}
               >
-                🗑️ クリア
+                <Trash2 size={16} aria-hidden="true" /> クリア
               </button>
             )}
           </div>
@@ -354,7 +363,7 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
                     gap: '0.25rem'
                   }}
                 >
-                  🗺️ Googleマップで表示
+                  <ExternalLink size={14} aria-hidden="true" /> Googleマップで表示
                 </a>
               </div>
             )}
@@ -371,7 +380,9 @@ export const GPSLocationInput: React.FC<GPSLocationInputProps> = ({
               borderRadius: '4px',
               fontSize: '0.9rem'
             }}>
-              ⚠️ {error}
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <AlertTriangle size={16} color="#F59E0B" aria-hidden="true" /> {error}
+              </span>
             </div>
           )}
         </div>

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -1,6 +1,7 @@
 // 写真アップロード・プレビューコンポーネント
 
 import React, { useCallback, useState } from 'react';
+import { Camera, MapPin, CheckCircle, Smartphone, AlertTriangle } from 'lucide-react';
 import { customValidationRules } from '../hooks/useFormValidation';
 import { photoMetadataService } from '../lib/photo-metadata-service';
 import { weatherService } from '../lib/weather-service';
@@ -303,11 +304,11 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
           ) : (
             <div>
               <div style={{
-                fontSize: '2rem',
                 marginBottom: '1rem',
-                color: disabled ? '#6c757d' : '#007bff'
+                display: 'flex',
+                justifyContent: 'center'
               }}>
-                📷
+                <Camera size={40} color={disabled ? '#6c757d' : '#007bff'} aria-hidden="true" />
               </div>
               <p style={{ margin: '0 0 0.5rem 0', fontWeight: 'bold' }}>
                 {dragOver ? 'ここにドロップ' : '写真をアップロード'}
@@ -315,15 +316,19 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
               <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.9rem', color: '#666' }}>
                 ドラッグ&amp;ドロップまたはクリックして選択
               </p>
-              <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.8rem', color: '#007bff', fontWeight: 'bold' }}>
-                📍 GPS情報付きの写真なら位置・日時・天気・海面水温を自動入力！
+              <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.8rem', color: '#007bff', fontWeight: 'bold', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
+                <MapPin size={14} color="#10B981" aria-hidden="true" /> GPS情報付きの写真なら位置・日時・天気・海面水温を自動入力!
               </p>
               <p style={{ margin: 0, fontSize: '0.8rem', color: '#666' }}>
                 対応形式: JPEG, PNG, WebP (最大{maxSizeMB}MB)
               </p>
               <div style={{ margin: '0.5rem 0 0 0', fontSize: '0.75rem', color: '#888' }}>
-                <p style={{ margin: 0 }}>✅ GPS付き写真: 位置・日時・天気・海面水温を自動抽出</p>
-                <p style={{ margin: 0 }}>📱 位置情報ONで撮影した写真がおすすめ</p>
+                <p style={{ margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
+                  <CheckCircle size={12} color="#10B981" aria-hidden="true" /> GPS付き写真: 位置・日時・天気・海面水温を自動抽出
+                </p>
+                <p style={{ margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
+                  <Smartphone size={12} color="#6B7280" aria-hidden="true" /> 位置情報ONで撮影した写真がおすすめ
+                </p>
               </div>
             </div>
           )}
@@ -384,7 +389,9 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
             gap: '1rem'
           }}
         >
-          <span>⚠️ {error || uploadError}</span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <AlertTriangle size={16} color="#F59E0B" aria-hidden="true" /> {error || uploadError}
+          </span>
           {uploadError && (
             <button
               type="button"


### PR DESCRIPTION
## Summary
- DataExportModal.tsx: 絵文字（📤📄📊📅📷✅❌⏳✕）をLucideアイコンに置き換え
- DataImportModal.tsx: 絵文字（📥💡📁📎✅❌⚠️⏳✕）をLucideアイコンに置き換え
- GPSLocationInput.tsx: 絵文字（📍✏️🗑️🗺️⚠️）をLucideアイコンに置き換え
- PhotoUpload.tsx: 絵文字（📷📍✅📱⚠️）をLucideアイコンに置き換え
- FishSpeciesAutocomplete.css: 絵文字（⚠🔍）をインラインSVGに置き換え
- 全アイコンに `aria-hidden="true"` を設定しアクセシビリティ対応

## Test plan
- [x] ビルドが成功
- [x] 既存テストがパス（パフォーマンステストの環境依存フレーキーテスト1件除く）
- [ ] ダークモードでの視認性確認（手動）
- [ ] タッチターゲット確認（手動）

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)