### PR TITLE
feat(ui): Phase 3 - 潮汐/釣果表示コンポーネントの絵文字をLucideアイコンに置き換え

### DIFF
--- a/src/components/SimplePhotoList.tsx
+++ b/src/components/SimplePhotoList.tsx
@@ -1,6 +1,7 @@
 // シンプルな写真ベース記録一覧（フォールバック版）
 
 import React from 'react';
+import { AlertTriangle, Fish, Camera, FileText } from 'lucide-react';
 import { PhotoBasedRecordCard } from './PhotoBasedRecordCard';
 import type { FishingRecord } from '../types';
 
@@ -35,7 +36,9 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
         borderRadius: '8px',
         margin: '1rem 0'
       }}>
-        <h3>⚠️ データの読み込みに失敗しました</h3>
+        <h3 style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}>
+          <AlertTriangle size={24} color="#F59E0B" aria-hidden="true" /> データの読み込みに失敗しました
+        </h3>
         <p>{error}</p>
         <button
           onClick={onDataRefresh}
@@ -69,8 +72,8 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
         marginBottom: '1.5rem',
         border: '1px solid #dee2e6'
       }}>
-        <h2 style={{ margin: 0, color: '#333', fontSize: '1.5rem' }}>
-          📸 写真で確認 ({records.length}件)
+        <h2 style={{ margin: 0, color: '#333', fontSize: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <Camera size={24} color="#007bff" aria-hidden="true" /> 写真で確認 ({records.length}件)
         </h2>
         <div style={{
           display: 'flex',
@@ -79,8 +82,12 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
           fontSize: '0.875rem',
           color: '#6c757d'
         }}>
-          <span>📸 写真付き: {recordsWithPhotos.length}件</span>
-          <span>📝 写真なし: {recordsWithoutPhotos.length}件</span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <Camera size={14} color="#6c757d" aria-hidden="true" /> 写真付き: {recordsWithPhotos.length}件
+          </span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <FileText size={14} color="#6c757d" aria-hidden="true" /> 写真なし: {recordsWithoutPhotos.length}件
+          </span>
         </div>
       </div>
 
@@ -111,7 +118,9 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
           borderRadius: '8px',
           border: '1px solid #dee2e6'
         }}>
-          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>🐟</div>
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '1rem' }}>
+            <Fish size={48} color="#9CA3AF" aria-hidden="true" />
+          </div>
           <h3>釣果記録がありません</h3>
           <p>デバッグタブでテスト記録を作成してみましょう！</p>
         </div>
@@ -128,7 +137,7 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
                 alignItems: 'center',
                 gap: '0.5rem'
               }}>
-                📸 写真付き記録 ({recordsWithPhotos.length}件)
+                <Camera size={20} color="#007bff" aria-hidden="true" /> 写真付き記録 ({recordsWithPhotos.length}件)
               </h3>
               <div style={{
                 display: 'grid',
@@ -160,7 +169,7 @@ export const SimplePhotoList: React.FC<SimplePhotoListProps> = ({
                 alignItems: 'center',
                 gap: '0.5rem'
               }}>
-                📝 写真なし記録 ({recordsWithoutPhotos.length}件)
+                <FileText size={20} color="#6c757d" aria-hidden="true" /> 写真なし記録 ({recordsWithoutPhotos.length}件)
               </h3>
               <div style={{
                 display: 'grid',

--- a/src/components/TideEventsList.tsx
+++ b/src/components/TideEventsList.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import { Calendar, Waves, Palmtree } from 'lucide-react';
 import type { TideEvent } from '../types/tide';
 import { filterTodayEvents } from '../lib/tide-helpers';
 
@@ -37,7 +38,9 @@ export const TideEventsList: React.FC<TideEventsListProps> = ({
         data-testid="empty-events-state"
         className="text-center py-8 text-gray-500"
       >
-        <div className="text-4xl mb-2">📅</div>
+        <div className="flex justify-center mb-2">
+          <Calendar size={40} color="#6B7280" aria-hidden="true" />
+        </div>
         <div className="text-sm">今日の潮汐イベントがありません</div>
       </div>
     );
@@ -67,9 +70,13 @@ export const TideEventsList: React.FC<TideEventsListProps> = ({
             {/* アイコン */}
             <div
               data-testid={isHighTide ? 'high-tide-icon' : 'low-tide-icon'}
-              className="flex-shrink-0 text-2xl"
+              className="flex-shrink-0 flex items-center justify-center"
             >
-              {isHighTide ? '🌊' : '🏖️'}
+              {isHighTide ? (
+                <Waves size={24} color="#0EA5E9" aria-hidden="true" />
+              ) : (
+                <Palmtree size={24} color="#F59E0B" aria-hidden="true" />
+              )}
             </div>
 
             {/* イベント詳細 */}

--- a/src/components/TideGraph.tsx
+++ b/src/components/TideGraph.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
+import { Fish } from 'lucide-react';
 import type { TideGraphData } from '../types/tide';
 import { useResizeObserver } from '../hooks/useResizeObserver';
 import { calculateSVGDimensions, createResponsiveConfig } from '../utils/responsive';
@@ -639,14 +640,16 @@ export const TideGraph: React.FC<TideGraphProps> = ({
                 stroke="white"
                 strokeWidth="2"
               />
-              <text
-                x={xScale(marker)}
-                y={-5}
-                textAnchor="middle"
-                className="text-xs font-medium fill-amber-600"
+              <foreignObject
+                x={xScale(marker) - 10}
+                y={-18}
+                width="20"
+                height="20"
               >
-                🎣
-              </text>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Fish size={16} color="#10B981" aria-hidden="true" />
+                </div>
+              </foreignObject>
             </g>
           ))}
 

--- a/src/components/TideSummaryCard.tsx
+++ b/src/components/TideSummaryCard.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { ModernCard } from './ui/ModernCard';
 import { TideSummaryGrid } from './TideSummaryGrid';
 import { TideEventsList } from './TideEventsList';
@@ -53,7 +54,9 @@ export const TideSummaryCard: React.FC<TideSummaryCardProps> = ({
     return (
       <ModernCard className={className}>
         <div data-testid="summary-card-error" className="p-6 text-center">
-          <div className="text-red-500 text-lg mb-2">⚠️</div>
+          <div className="flex justify-center mb-2">
+            <AlertTriangle size={28} color="#F59E0B" aria-hidden="true" />
+          </div>
           <div className="text-red-600 font-medium">潮汐データエラー</div>
           <div className="text-red-500 text-sm mt-1">
             {error || '潮汐情報を取得できませんでした'}

--- a/src/components/map/FishingMap.tsx
+++ b/src/components/map/FishingMap.tsx
@@ -113,12 +113,22 @@ const createCustomIcon = (species: string, size?: number) => {
             justify-content: center;
             transform: rotate(45deg);
           ">
-            <span style="
-              color: white;
-              font-size: ${iconSize * 0.5}px;
-              font-weight: bold;
-              filter: drop-shadow(0 1px 3px rgba(0,0,0,0.4));
-            ">🐟</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="${iconSize * 0.5}"
+              height="${iconSize * 0.5}"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              style="filter: drop-shadow(0 1px 3px rgba(0,0,0,0.4));"
+            >
+              <path d="M6.5 12c.94-3.46 4.94-6 8.5-6 3.56 0 6.06 2.54 7 6-.94 3.47-3.44 6-7 6-3.56 0-7.56-2.53-8.5-6Z"/>
+              <circle cx="15" cy="12" r="1"/>
+              <path d="M2 12S5.5 8 6.5 12s-4.5 0-4.5 0Z"/>
+            </svg>
           </div>
         </div>
         <div class="marker-dot" style="


### PR DESCRIPTION
## Summary
- TideEventsList.tsx: 絵文字（📅🌊🏖️）をLucideアイコン（Calendar, Waves, Palmtree）に置き換え
- TideGraph.tsx: 釣果マーカーの絵文字（🎣）をFishアイコン（foreignObject使用）に置き換え
- TideSummaryCard.tsx: エラー表示の絵文字（⚠️）をAlertTriangleアイコンに置き換え
- SimplePhotoList.tsx: 絵文字（⚠️🐟📸📝）をLucideアイコンに置き換え
- FishingMap.tsx: 地図マーカー内の絵文字（🐟）をインラインSVGに置き換え
- TideSummaryGrid.tsx: 既にLucideアイコン使用済み（変更なし）
- 全アイコンに `aria-hidden="true"` を設定しアクセシビリティ対応

## Test plan
- [x] ビルドが成功
- [x] 既存テスト（68件）がパス
- [ ] 潮汐グラフの釣果マーカー表示確認（手動）
- [ ] 地図マーカーの表示確認（手動）
- [ ] ダークモードでの視認性確認（手動）

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)