### PR TITLE
fix(map): fix marker display and improve UI/UX

### DIFF
--- a/src/components/map/FishingMap.tsx
+++ b/src/components/map/FishingMap.tsx
@@ -79,16 +79,30 @@ const getFishSpeciesColor = (species: string): string => {
   return colorMap[species] || colors.primary[500];
 };
 
-// モダンなカスタムピンアイコン
-const createCustomIcon = (species: string, size?: number) => {
+// 背景色の明度を計算してアイコン色を決定
+const getBrightness = (hex: string): number => {
+  const rgb = parseInt(hex.slice(1), 16);
+  const r = (rgb >> 16) & 0xff;
+  const g = (rgb >> 8) & 0xff;
+  const b = (rgb >> 0) & 0xff;
+  return (r * 299 + g * 587 + b * 114) / 1000;
+};
+
+// モダンなカスタムピンアイコン（修正版）
+const createCustomIcon = (species: string, size?: number, isSelected?: boolean) => {
   const color = getFishSpeciesColor(species);
-  const iconSize = size ? Math.min(Math.max(size / 8, 28), 44) : 36;
-  const dotSize = iconSize * 0.25;
+  // 最小タッチターゲットサイズを44pxに修正（iOS HIG / Material Design 3推奨）
+  const iconSize = size ? Math.min(Math.max(size / 8, 44), 56) : 48;
+  const dotSize = 8; // 固定サイズで視認性向上
+  const scale = isSelected ? 1.3 : 1; // 選択時に拡大
+
+  // 背景色の明度に応じてアイコン色を自動調整（WCAG 2.1コントラスト比対応）
+  const iconColor = getBrightness(color) > 128 ? '#000000' : '#ffffff';
 
   return L.divIcon({
     className: 'custom-marker',
     html: `
-      <div class="marker-wrapper">
+      <div class="marker-wrapper" style="transform: scale(${scale}); transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);">
         <div class="marker-pin" style="
           background: linear-gradient(135deg, ${color} 0%, ${color}dd 100%);
           width: ${iconSize}px;
@@ -96,17 +110,19 @@ const createCustomIcon = (species: string, size?: number) => {
           border-radius: 50% 50% 50% 0;
           transform: rotate(-45deg);
           box-shadow:
-            0 3px 8px rgba(0,0,0,0.3),
-            inset 0 -2px 4px rgba(0,0,0,0.2);
+            0 4px 12px rgba(0,0,0,0.25),
+            inset 0 -2px 4px rgba(0,0,0,0.2)${isSelected ? `, 0 0 0 4px ${color}44, 0 0 20px ${color}66` : ''};
           display: flex;
           align-items: center;
           justify-content: center;
           position: relative;
+          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         ">
           <div class="marker-inner" style="
-            background: rgba(255,255,255,0.25);
-            width: ${iconSize * 0.7}px;
-            height: ${iconSize * 0.7}px;
+            background: rgba(255,255,255,0.3);
+            backdrop-filter: blur(4px);
+            width: ${iconSize * 0.65}px;
+            height: ${iconSize * 0.65}px;
             border-radius: 50%;
             display: flex;
             align-items: center;
@@ -115,19 +131,19 @@ const createCustomIcon = (species: string, size?: number) => {
           ">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="${iconSize * 0.5}"
-              height="${iconSize * 0.5}"
+              width="${iconSize * 0.45}"
+              height="${iconSize * 0.45}"
               viewBox="0 0 24 24"
               fill="none"
-              stroke="white"
-              stroke-width="2"
+              stroke="${iconColor}"
+              stroke-width="2.5"
               stroke-linecap="round"
               stroke-linejoin="round"
-              style="filter: drop-shadow(0 1px 3px rgba(0,0,0,0.4));"
+              style="filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));"
             >
-              <path d="M6.5 12c.94-3.46 4.94-6 8.5-6 3.56 0 6.06 2.54 7 6-.94 3.47-3.44 6-7 6-3.56 0-7.56-2.53-8.5-6Z"/>
-              <circle cx="15" cy="12" r="1"/>
-              <path d="M2 12S5.5 8 6.5 12s-4.5 0-4.5 0Z"/>
+              <path d="M6.5 12c.94-3.46 4.94-6 8.5-6 3.56 0 6.06 2.54 7 6-.94 3.47-3.44 6-7 6-3.56 0-7.56-2.53-8.5-6Z"></path>
+              <circle cx="15" cy="12" r="1"></circle>
+              <path d="M2 12S5.5 8 6.5 12s-4.5 0-4.5 0Z"></path>
             </svg>
           </div>
         </div>
@@ -140,7 +156,7 @@ const createCustomIcon = (species: string, size?: number) => {
           height: ${dotSize}px;
           background: radial-gradient(circle, ${color} 0%, ${color}88 100%);
           border-radius: 50%;
-          box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+          box-shadow: 0 3px 8px rgba(0,0,0,0.4);
         "></div>
       </div>
     `,
@@ -433,7 +449,11 @@ export const FishingMap: React.FC<FishingMapProps> = ({ records, onRecordClick, 
             <Marker
               key={record.id}
               position={[record.adjustedLat, record.adjustedLng]}
-              icon={createCustomIcon(record.fishSpecies, record.size || record.weight)}
+              icon={createCustomIcon(
+                record.fishSpecies,
+                record.size || record.weight,
+                selectedRecord?.id === record.id
+              )}
               eventHandlers={{
                 click: () => {
                   setSelectedRecord(record);


### PR DESCRIPTION
## Summary
- **Problem**: Map markers were not displaying after Phase 3 emoji replacement
- **Root Cause**: SVG self-closing tags (`/>`) were not properly parsed in L.divIcon HTML strings
- **Solution**: Replace with explicit closing tags (`</path>`, `</circle>`)

## Designer Review Improvements
- Minimum touch target size: 44px (iOS HIG / Material Design 3)
- Auto-contrast icon color based on background brightness (WCAG 2.1)
- Selected marker visual feedback: 1.3x scale + glow effect
- Enhanced glassmorphism with backdrop-filter
- Smooth animations with cubic-bezier easing

## Test plan
- [ ] Verify markers display on map with GPS-tagged records
- [ ] Test marker selection visual feedback (scale + glow)
- [ ] Verify icon contrast on different species colors
- [ ] Test touch targets on mobile (44px minimum)
- [ ] Run `npm run build` - build succeeds
- [ ] Run `npm run test:fast` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)