### PR TITLE
feat(map): implement Phase 2 marker improvements (#293, #294, #295)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.1",
+        "@types/leaflet.markercluster": "^1.5.6",
         "@types/node": "^24.5.2",
         "@types/piexifjs": "^1.0.0",
         "@types/react": "^18.2.45",
@@ -2479,6 +2480,16 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@types/leaflet.heat/-/leaflet.heat-0.2.5.tgz",
       "integrity": "sha512-wmDePJPn2vhW9BScsWTV4pSfWayhdDwXuWIQzUuaJkvk5DCHsYsIegTD7tybo38E/0mxpuWODKV/LhsxPESWJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "^1.9"
+      }
+    },
+    "node_modules/@types/leaflet.markercluster": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.6.tgz",
+      "integrity": "sha512-I7hZjO2+isVXGYWzKxBp8PsCzAYCJBc29qBdFpquOCkS7zFDqUsUvkEOyQHedsk/Cy5tocQzf+Ndorm5W9YKTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/leaflet": "^1.9"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
+    "@types/leaflet.markercluster": "^1.5.6",
     "@types/node": "^24.5.2",
     "@types/piexifjs": "^1.0.0",
     "@types/react": "^18.2.45",


### PR DESCRIPTION
## Summary

Phase 2 of the map marker improvements based on designer research:

- **#293 Click Animation**: Added `markerBounce` CSS animation for tactile feedback on marker click
- **#294 Clustering**: Implemented `MarkerClusterGroup` for automatic marker grouping at low zoom levels
- **#295 Time-based Pulse**: Recent catches (within 1 week) now have a pulsing blue glow animation

## Changes

### Issue #293: Click Animation Enhancement
- Added `markerBounce` CSS animation (0.4s cubic-bezier bounce effect)
- Applied on `:active` state for immediate tactile feedback

### Issue #294: MarkerClusterGroup Implementation  
- Integrated `react-leaflet-cluster` for automatic marker clustering
- Custom cluster icons with size based on child count:
  - <10 markers: 44px
  - <50 markers: 52px
  - 50+ markers: 60px
- Spiderfy on max zoom for accessibility
- Added `@types/leaflet.markercluster` for TypeScript support

### Issue #295: Time-based Pulse Animation
- Added `isRecentCatch()` function to detect catches within 1 week
- `recentPulse` CSS animation (2s infinite) with blue glow effect
- `marker-recent` class automatically applied to recent markers

## Test Plan

- [ ] Build passes: `npm run build`
- [ ] Click on markers - should see bounce animation
- [ ] Zoom out to see markers cluster
- [ ] Check that recent catches (within 1 week) have pulse animation
- [ ] Verify cluster icons display correct count

Closes #293
Closes #294
Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)