### PR TITLE
fix(map): remove dark mode tile layer for better readability

### DIFF
--- a/src/components/map/FishingMap.tsx
+++ b/src/components/map/FishingMap.tsx
@@ -550,7 +550,7 @@ export const FishingMap: React.FC<FishingMapProps> = ({ records, onRecordClick, 
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        backgroundColor: isDarkMode ? '#1a1a2e' : colors.background.primary,
+        backgroundColor: colors.background.primary,
         outline: 'none',
       }}
     >
@@ -570,13 +570,11 @@ export const FishingMap: React.FC<FishingMapProps> = ({ records, onRecordClick, 
           maxBounds={JAPAN_BOUNDS}
           maxBoundsViscosity={0.9}
         >
-          {/* Issue #296: ダークモード対応タイルレイヤー */}
+          {/* マップタイルは常に明るいOSM Japan（可読性重視） */}
+          {/* Issue #296: ダークモードはUIオーバーレイのみ対応 */}
           <TileLayer
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url={isDarkMode
-              ? "https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png"
-              : "https://tile.openstreetmap.jp/styles/osm-bright-ja/{z}/{x}/{y}.png"
-            }
+            url="https://tile.openstreetmap.jp/styles/osm-bright-ja/{z}/{x}/{y}.png"
             maxZoom={18}
           />
 


### PR DESCRIPTION
## Summary

Fixes the map readability issue caused by dark mode tile layer.

## Problem

The CartoDB dark tiles (`dark_all`) significantly reduced map readability:
- Low contrast labels and road names
- Difficult to read location names
- Poor visibility of map details

## Solution

- Remove dark tile layer, keep OSM Japan bright tiles for all modes
- Dark mode support still applies to markers (glow effects preserved)
- Map readability is prioritized over dark theme consistency

## Test Plan

- [ ] Map displays with bright tiles in both light and dark system modes
- [ ] Labels and roads are clearly readable
- [ ] Markers still have glow effects in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)