### PR TITLE
fix(layout): make bottom navigation fixed on scroll

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -85,7 +85,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
           <main style={{
             flex: 1,
             padding: '0',
-            overflow: 'hidden',
+            paddingBottom: navigation ? '64px' : '0',
+            overflow: 'auto',
           }}>
             {children}
           </main>
@@ -106,8 +107,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
       {/* ボトムナビゲーション（モバイルのみ） */}
       {navigation && (
         <nav style={{
-          position: 'sticky',
+          position: 'fixed',
           bottom: 0,
+          left: 0,
+          right: 0,
           zIndex: 100,
           backgroundColor: colors.surface.primary,
           borderTop: `1px solid ${colors.border.light}`,


### PR DESCRIPTION
## Summary
- ボトムナビゲーションをスクロール時も固定表示するように修正
- `position: sticky` から `position: fixed` に変更
- コンテンツ下部にパディングを追加してナビゲーションとの重なりを防止

## Test plan
- [ ] 記録一覧画面で長いリストをスクロールし、ナビゲーションが固定されることを確認
- [ ] 各タブ（ホーム、記録一覧、地図、新規記録、設定）の切り替えが正常に動作することを確認
- [ ] コンテンツの最下部までスクロールでき、ナビゲーションに隠れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)