### PR TITLE
fix(theme): fix light mode text visibility issues

### DIFF
--- a/src/components/FishingRecordForm.tsx
+++ b/src/components/FishingRecordForm.tsx
@@ -529,7 +529,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.date ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.date ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -628,7 +628,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.location ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.location ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -714,7 +714,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.weather ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.weather ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -805,7 +805,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.seaTemperature ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.seaTemperature ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -921,7 +921,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.size ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.size ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -999,7 +999,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.weight ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.weight ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />
@@ -1074,7 +1074,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
               e.target.style.boxShadow = '0 0 0 3px rgba(96,165,250,0.25)';
             }}
             onBlur={(e) => {
-              e.target.style.borderColor = errors.notes ? '#ef4444' : 'rgba(255, 255, 255, 0.15)';
+              e.target.style.borderColor = errors.notes ? '#ef4444' : 'var(--color-border-medium)';
               e.target.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
             }}
           />

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -322,12 +322,12 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
               <p style={{ margin: 0, fontSize: '0.8rem', color: 'var(--color-text-secondary)' }}>
                 対応形式: JPEG, PNG, WebP (最大{maxSizeMB}MB)
               </p>
-              <div style={{ margin: '0.5rem 0 0 0', fontSize: '0.75rem', color: 'rgba(255, 255, 255, 0.5)' }}>
+              <div style={{ margin: '0.5rem 0 0 0', fontSize: '0.75rem', color: 'var(--color-text-tertiary)' }}>
                 <p style={{ margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
                   <CheckCircle size={12} color="#10B981" aria-hidden="true" /> GPS付き写真: 位置・日時・天気・海面水温を自動抽出
                 </p>
                 <p style={{ margin: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
-                  <Smartphone size={12} color="#6B7280" aria-hidden="true" /> 位置情報ONで撮影した写真がおすすめ
+                  <Smartphone size={12} style={{ color: 'var(--color-text-secondary)' }} aria-hidden="true" /> 位置情報ONで撮影した写真がおすすめ
                 </p>
               </div>
             </div>

--- a/src/components/SavedSearchManager.tsx
+++ b/src/components/SavedSearchManager.tsx
@@ -369,7 +369,7 @@ export const SavedSearchManager: React.FC<SavedSearchManagerProps> = ({
                       <p style={{
                         margin: 0,
                         fontSize: '0.75rem',
-                        color: 'rgba(255, 255, 255, 0.5)'
+                        color: 'var(--color-text-tertiary)'
                       }}>
                         作成: {formatDate(search.createdAt)}
                       </p>


### PR DESCRIPTION
## Summary
- ライトモード時にテキストが見えなくなる問題を修正
- ハードコードされた `rgba(255, 255, 255, *)` 色をCSS変数に置き換え

## Changes

### PhotoUpload.tsx
- `rgba(255, 255, 255, 0.5)` → `var(--color-text-tertiary)`: GPS情報の補足テキスト
- Smartphoneアイコンの色を `var(--color-text-secondary)` に変更

### SavedSearchManager.tsx
- `rgba(255, 255, 255, 0.5)` → `var(--color-text-tertiary)`: 作成日時テキスト

### FishingRecordForm.tsx
- `rgba(255, 255, 255, 0.15)` → `var(--color-border-medium)`: 入力フィールドのボーダー色（7箇所）

## Test plan
- [x] `npm run typecheck` - 型チェック成功
- [x] `npm run test:fast` - 全1535テスト成功
- [ ] ライトモードで写真アップロード欄のテキストが見えることを確認
- [ ] ライトモードでフォーム入力欄のボーダーが適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)