### PR TITLE
fix(form): use type=search to prevent iOS Safari AutoFill bar

### DIFF
--- a/src/components/FishSpeciesAutocomplete.tsx
+++ b/src/components/FishSpeciesAutocomplete.tsx
@@ -212,7 +212,8 @@ export const FishSpeciesAutocomplete: React.FC<FishSpeciesAutocompleteProps> = (
       <div className="input-wrapper">
         <input
           ref={inputRef}
-          type="text"
+          type="search"
+          inputMode="text"
           autoComplete="off"
           autoCorrect="off"
           spellCheck="false"

--- a/src/components/FishingRecordForm.tsx
+++ b/src/components/FishingRecordForm.tsx
@@ -621,7 +621,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
           <input
             id="fishing-spot"
             data-testid={TestIds.LOCATION_NAME}
-            type="text"
+            type="search"
             readOnly
             autoComplete="off"
             autoCorrect="off"
@@ -722,7 +722,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
           <input
             id="weather"
             data-testid={TestIds.WEATHER}
-            type="text"
+            type="search"
             readOnly
             autoComplete="off"
             autoCorrect="off"

--- a/src/index.css
+++ b/src/index.css
@@ -315,3 +315,14 @@ input:-webkit-autofill:active {
   -webkit-text-fill-color: var(--color-text-primary) !important;
   transition: background-color 5000s ease-in-out 0s;
 }
+
+/* type="search"の×ボタン（クリアボタン）を非表示 */
+/* Safari/Chrome/Edge共通 */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}


### PR DESCRIPTION
## Summary
- テキスト入力フィールド（場所、天候、魚種）を`type="search"`に変更
- Safari/Chromeが検索フィールドにはAutoFill候補を表示しない仕様を利用
- `inputMode="text"`で通常のキーボードレイアウトを維持
- 検索フィールドに表示される×ボタンを非表示にするCSSを追加

## Background
iOS Safari では、テキストフィールドに入力する際にキーボード上部にAutoFillバー（パスワード/カード/連絡先アイコン）が表示される問題がありました。

PR #311〜#314で様々なアプローチを試しましたが効果がなく、Web調査の結果、`type="search"`が最も効果的なワークアラウンドであることが判明しました。

### Technical Details
- `type="search"`はSafariに検索入力として認識させ、AutoFill候補の表示を回避
- `inputMode="text"`を併用することで、通常のテキストキーボードを維持
- `-webkit-search-cancel-button`等の疑似要素を非表示にするCSSを追加

## Test plan
- [ ] iOS Safari実機でフォームを開き、各フィールドをタップした際にAutoFillバーが表示されないことを確認
- [ ] 各フィールドで通常のテキスト入力が正常に動作することを確認
- [ ] 検索フィールドの×ボタンが表示されないことを確認
- [ ] 既存のE2Eテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)