### PR TITLE
fix(ui): モバイルで潮汐グラフサイズをレスポンシブ対応

### DIFF
--- a/src/components/record/PhotoHeroCard.css
+++ b/src/components/record/PhotoHeroCard.css
@@ -358,12 +358,25 @@
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   /* Container size - fit for CompactTideChart with tide name */
-  width: 180px;
-  height: 100px;
+  /* Mobile: scaled down for better fit */
+  width: 140px;
+  height: 78px;
   /* Ensure clean rendering */
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Scale internal Recharts component to fit smaller container */
+  transform: scale(0.78);
+  transform-origin: top right;
+}
+
+/* Tablet and up: original size */
+@media (min-width: 769px) {
+  .photo-hero-card__tide-chart-overlay {
+    width: 180px;
+    height: 100px;
+    transform: scale(1);
+  }
 }
 
 /* Inner container for tide chart content */
@@ -387,14 +400,23 @@
 
 /* Tide Loading Indicator */
 .photo-hero-card__tide-loading {
-  width: 160px;
-  height: 80px;
+  /* Mobile: smaller size */
+  width: 110px;
+  height: 62px;
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);
   border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Tablet and up: original size */
+@media (min-width: 769px) {
+  .photo-hero-card__tide-loading {
+    width: 160px;
+    height: 80px;
+  }
 }
 
 .photo-hero-card__tide-loading-spinner {


### PR DESCRIPTION
## Summary
- モバイル(768px以下)で潮汐グラフを0.78倍にスケールダウン
- ローディングインジケータも同様に調整

## Test plan
- [ ] モバイルサイズで潮汐グラフが適切なサイズで表示されること
- [ ] タブレット以上では元のサイズで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)