### PR TITLE
fix(ui): 情報パネルの位置・サイズを確実に反映

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -366,11 +366,12 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           }
 
           // 保存用: 情報パネル（日時・場所等）を上部に移動＆サイズ拡大
+          // CSSで !important が使われているため setProperty で上書き
           const infoPanel = clonedElement.querySelector('.photo-hero-card__info-panel') as HTMLElement;
           if (infoPanel) {
-            infoPanel.style.top = '12px';
-            infoPanel.style.transform = 'scale(1.2)';
-            infoPanel.style.transformOrigin = 'top left';
+            infoPanel.style.setProperty('top', '12px', 'important');
+            infoPanel.style.setProperty('transform', 'scale(1.2)', 'important');
+            infoPanel.style.setProperty('transform-origin', 'top left', 'important');
           }
         },
         // Ignore elements that cause issues


### PR DESCRIPTION
## Summary
- 情報パネル（日時・場所等）のスタイル上書きが効いていなかった問題を修正

## 原因
CSSで `!important` が使われていたため、通常のインラインスタイル設定では上書きできなかった

## 修正内容
`style.setProperty()` で `'important'` 優先度を指定して確実に上書き

```javascript
// Before
infoPanel.style.top = '12px';

// After
infoPanel.style.setProperty('top', '12px', 'important');
```

## Test plan
- [ ] iPhoneで保存
- [ ] 情報パネルが上部に移動していることを確認
- [ ] 情報パネルがサイズ拡大されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)