### PR TITLE
fix(ui): 全体表示時は「タップして地図を表示」を非表示に

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -1095,7 +1095,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
                 tideChartData={tideChartData ?? undefined}
                 fishingTime={fishingTimeForChart}
                 tideLoading={tideLoading}
-                showMapHint={!!record.coordinates}
+                showMapHint={!!record.coordinates && photoFitMode === 'cover'}
                 fullscreen={true}
                 transparentInfo={true}
                 fitMode={photoFitMode}
@@ -1127,7 +1127,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
                   tideChartData={tideChartData ?? undefined}
                   fishingTime={fishingTimeForChart}
                   tideLoading={tideLoading}
-                  showMapHint={!!record.coordinates}
+                  showMapHint={!!record.coordinates && photoFitMode === 'cover'}
                   fitMode={photoFitMode}
                 />
               </div>


### PR DESCRIPTION
## Summary
- 写真詳細画面で全体表示（contain）時は「タップして地図を表示」を非表示に
- 拡大（cover）時のみ表示するよう変更

## Test plan
- [x] 全体表示時: ヒント非表示
- [x] 拡大時: ヒント表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)