### PR TITLE
fix(map): モバイル時の写真サイズを調整

### DIFF
--- a/src/components/map/FishingMap.tsx
+++ b/src/components/map/FishingMap.tsx
@@ -754,7 +754,7 @@ export const FishingMap: React.FC<FishingMapProps> = ({ records, onRecordClick, 
                   alt={`${selectedRecord.fishSpecies}の写真`}
                   style={{
                     width: '100%',
-                    maxHeight: '200px',
+                    maxHeight: isMobile ? '150px' : '200px',
                     objectFit: 'cover',
                     display: 'block',
                   }}


### PR DESCRIPTION
## Summary
- モバイルでの写真maxHeightを200px → 150pxに調整
- Bottom Sheetレイアウトでの見切れを防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)