### PR TITLE
fix(ui): 写真詳細画面でフッターを表示

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -534,7 +534,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
         top: 0,
         left: 0,
         right: 0,
-        bottom: 0,
+        bottom: isMobile ? '56px' : 0, // モバイルはフッター分を確保
         backgroundColor: 'rgba(0,0,0,0.5)',
         display: 'flex',
         alignItems: 'center',
@@ -574,7 +574,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           top: 0,
           left: 0,
           right: 0,
-          bottom: 0,
+          bottom: isMobile ? '56px' : 0, // モバイルはフッター分を確保
           backgroundColor: isMobile ? 'var(--color-surface-primary)' : 'rgba(0,0,0,0.5)',
           display: 'flex',
           alignItems: isMobile ? 'stretch' : 'center',

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -107,7 +107,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
           bottom: 0,
           left: 0,
           right: 0,
-          zIndex: 100,
+          zIndex: 1100, // FishingRecordDetail(1000)より上に表示
           // モバイルでのみ表示（CSSメディアクエリは別途追加）
           display: 'block',
         }}>


### PR DESCRIPTION
## Summary
- 写真詳細画面を開いた時にフッター（BottomNavigation）が非表示になる問題を修正

## 変更内容
- AppLayout: ナビゲーションのz-indexを100 → 1100に変更
- FishingRecordDetail: モバイル時に`bottom: 56px`でフッター領域を確保

🤖 Generated with [Claude Code](https://claude.com/claude-code)