### PR TITLE
fix(ui): フッター上の余計なスペースを削除

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -534,7 +534,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
         top: 0,
         left: 0,
         right: 0,
-        bottom: isMobile ? '56px' : 0, // モバイルはフッター分を確保
+        bottom: 0,
         backgroundColor: 'rgba(0,0,0,0.5)',
         display: 'flex',
         alignItems: 'center',
@@ -574,7 +574,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           top: 0,
           left: 0,
           right: 0,
-          bottom: isMobile ? '56px' : 0, // モバイルはフッター分を確保
+          bottom: 0,
           backgroundColor: isMobile ? 'var(--color-surface-primary)' : 'rgba(0,0,0,0.5)',
           display: 'flex',
           alignItems: isMobile ? 'stretch' : 'center',


### PR DESCRIPTION
## Summary
- フッター上に余計な56pxのスペースが表示される問題を修正
- z-indexでフッターを上に表示するため、bottom: 56pxは不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)