### PR TITLE
fix(map): 詳細を見るクリック時にサマリパネルを閉じる

### DIFF
--- a/src/components/map/FishingMap.tsx
+++ b/src/components/map/FishingMap.tsx
@@ -741,7 +741,10 @@ export const FishingMap: React.FC<FishingMapProps> = ({ records, onRecordClick, 
             {/* アクションボタン */}
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
               <button
-                onClick={() => onRecordClick?.(selectedRecord)}
+                onClick={() => {
+                  onRecordClick?.(selectedRecord);
+                  setSelectedRecord(null);
+                }}
                 style={{
                   width: '100%',
                   padding: '12px',


### PR DESCRIPTION
## Summary
- 「詳細を見る」ボタンクリック時にサマリパネルが表示されたままになる問題を修正
- `setSelectedRecord(null)` を追加してパネルを閉じる

## Test plan
- [x] 釣り場マップでピンをタップ
- [x] 「詳細を見る」をクリック
- [x] サマリパネルが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)