### PR TITLE
fix(map): 詳細表示時にmapSelectedRecordIdをクリア

### DIFF
--- a/src/ModernApp.tsx
+++ b/src/ModernApp.tsx
@@ -350,6 +350,9 @@ function ModernApp() {
   // 記録関連ハンドラー
   const handleRecordClick = (record: FishingRecord) => {
     setSelectedRecord(record);
+    // マップから詳細を見る場合、mapSelectedRecordIdをクリア
+    // （クリアしないとuseEffectで再度サマリパネルが表示される）
+    setMapSelectedRecordId(undefined);
   };
 
   const handleRecordEdit = (record: FishingRecord) => {


### PR DESCRIPTION
## Summary
- 写真詳細から「タップして地図を表示」→「詳細を見る」の場合にサマリパネルが閉じない問題を修正
- `handleRecordClick`で`mapSelectedRecordId`を`undefined`にクリア
- これによりFishingMapの`useEffect`による再設定を防止

## Test plan
- [x] 写真詳細から「タップして地図を表示」
- [x] サマリパネルの「詳細を見る」をクリック
- [x] サマリパネルが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)