### PR TITLE
fix(detail): pointer-eventsでフッターへのクリック透過を実装

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -580,7 +580,8 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           alignItems: isMobile ? 'stretch' : 'center',
           justifyContent: 'center',
           zIndex: 1000,
-          padding: isMobile ? 0 : '1rem'
+          padding: isMobile ? 0 : '1rem',
+          pointerEvents: 'none', // クリックを透過してフッターに届ける
         }}
         onClick={(e) => {
           if (!isMobile && e.target === e.currentTarget) {
@@ -607,7 +608,8 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             boxShadow: isMobile ? 'none' : '0 20px 40px rgba(0,0,0,0.3)',
             border: isMobile ? 'none' : `1px solid ${'var(--color-border-light)'}`,
             display: 'flex',
-            flexDirection: 'column'
+            flexDirection: 'column',
+            pointerEvents: 'auto', // コンテンツはクリック可能に
           }}
           role="dialog"
           aria-label={`${record.fishSpecies}の詳細`}


### PR DESCRIPTION
## Summary
写真詳細画面でフッターボタンがタップできない問題を修正。

### 根本原因
- 外側オーバーレイに`bottom: 56px`を設定しても
- 内側コンテンツが`position: absolute; bottom: 0`で親要素いっぱいに広がり
- フッター領域を覆っていた

### 解決策
- 外側オーバーレイ: `pointer-events: none`（クリック透過）
- 内側コンテンツ: `pointer-events: auto`（クリック可能）

## Test plan
- [x] 写真詳細画面を開く
- [x] フッターのホームボタンをタップ → ホーム画面に遷移
- [x] フッターの他のボタン（マップ、グラフ等）もタップ可能
- [x] 写真詳細画面内のボタン（戻る、メニュー等）も引き続きタップ可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)