### PR TITLE
fix(detail): React Portalでbody直下にレンダリング

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -1,6 +1,7 @@
 // 釣果記録詳細コンポーネント
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 // import { textStyles, typography } from '../theme/typography';
 import type { FishingRecord } from '../types';
 import type { TideChartData } from './chart/tide/types';
@@ -565,7 +566,8 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
     );
   }
 
-  return (
+  // createPortalでbody直下にレンダリングし、スタッキングコンテキストの問題を回避
+  return createPortal(
     <>
       {/* メインダイアログ */}
       <div
@@ -581,7 +583,6 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           justifyContent: 'center',
           zIndex: 1000,
           padding: isMobile ? 0 : '1rem',
-          pointerEvents: 'none', // クリックを透過してフッターに届ける
         }}
         onClick={(e) => {
           if (!isMobile && e.target === e.currentTarget) {
@@ -609,7 +610,6 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             border: isMobile ? 'none' : `1px solid ${'var(--color-border-light)'}`,
             display: 'flex',
             flexDirection: 'column',
-            pointerEvents: 'auto', // コンテンツはクリック可能に
           }}
           role="dialog"
           aria-label={`${record.fishSpecies}の詳細`}
@@ -1508,6 +1508,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           }
         }
       `}</style>
-    </>
+    </>,
+    document.body
   );
 };


### PR DESCRIPTION
## Summary
写真詳細画面でフッターボタンがタップできない問題を修正。

### 根本原因（なぜなぜ分析）
1. **なぜフッターがタップできない？** → タッチイベントが届かない
2. **なぜイベントが届かない？** → FishingRecordDetailが覆っている
3. **なぜz-indexが低いのに覆う？** → 別のスタッキングコンテキストにある
4. **なぜ別のコンテキスト？** → AppLayout内の異なる位置にレンダリング
5. **なぜDOM順序が問題？** → position: fixed同士はz-indexより描画順序が優先される

### 解決策
- `createPortal`で`document.body`直下にレンダリング
- AppLayoutのスタッキングコンテキストから完全に独立
- z-indexが正しく機能するようになる

## Test plan
- [x] 写真詳細画面を開く
- [x] フッターのホームボタンをタップ → ホーム画面に遷移
- [x] フッターの他のボタン（マップ、グラフ等）もタップ可能
- [x] 写真詳細画面内のボタン（戻る、メニュー、メモ等）も引き続きタップ可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)