### PR TITLE
fix(detail): 全モーダルでモバイルフッター領域を確保

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -1191,7 +1191,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: 0,
+            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
             backgroundColor: 'rgba(0, 0, 0, 0.7)',
             display: 'flex',
             alignItems: 'center',
@@ -1310,7 +1310,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: 0,
+            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
             backgroundColor: 'rgba(0, 0, 0, 0.85)',
             display: 'flex',
             flexDirection: 'column',
@@ -1420,12 +1420,12 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: 0,
+            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
             backgroundColor: 'rgba(0,0,0,0.9)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            zIndex: 1100,
+            zIndex: 1050, // フッター(1100)より下、メインダイアログ(1000)より上
             padding: '2rem'
           }}
           onClick={() => setPhotoExpanded(false)}


### PR DESCRIPTION
## Summary
- 写真拡大表示: z-index 1100→1050に変更、モバイルでbottom: 56px
- 削除確認モーダル: モバイルでbottom: 56px
- 共有モーダル: モバイルでbottom: 56px

## 根本原因
PR #357のPortal実装後も、Portal内の各モーダル（写真拡大、削除確認、共有）が`bottom: 0`で全画面を覆っていたため、フッターがタップできなかった。

特に写真拡大表示は`z-index: 1100`でフッターと同じだったため、DOM順序によりフッターより前面に表示されていた。

## Test plan
- [x] テスト通過
- [ ] モバイル実機で写真詳細画面→フッターボタンがタップ可能か確認
- [ ] 写真拡大時→フッターボタンがタップ可能か確認
- [ ] 削除確認モーダル表示時→フッターボタンがタップ可能か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)