### PR TITLE
fix(nav): フッタータップ時に詳細モーダルを閉じる

### DIFF
--- a/src/ModernApp.tsx
+++ b/src/ModernApp.tsx
@@ -1767,7 +1767,13 @@ function ModernApp() {
         navigation={
           <BottomNavigation
             items={navigationItems}
-            onItemClick={(id) => setActiveTab(id as any)}
+            onItemClick={(id) => {
+              setActiveTab(id as any);
+              // すべてのモーダルを閉じてナビゲーションを有効にする
+              setSelectedRecord(null);
+              setEditingRecord(null);
+              setDeletingRecord(null);
+            }}
           />
         }
       >

--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -576,7 +576,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
           top: 0,
           left: 0,
           right: 0,
-          bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
+          bottom: isMobile ? 56 : 0, // モバイル: フッターを視覚的に表示
           backgroundColor: isMobile ? 'var(--color-surface-primary)' : 'rgba(0,0,0,0.5)',
           display: 'flex',
           alignItems: isMobile ? 'stretch' : 'center',
@@ -1191,7 +1191,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
+            bottom: isMobile ? 56 : 0, // モバイル: フッターを視覚的に表示
             backgroundColor: 'rgba(0, 0, 0, 0.7)',
             display: 'flex',
             alignItems: 'center',
@@ -1310,7 +1310,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
+            bottom: isMobile ? 56 : 0, // モバイル: フッターを視覚的に表示
             backgroundColor: 'rgba(0, 0, 0, 0.85)',
             display: 'flex',
             flexDirection: 'column',
@@ -1420,7 +1420,7 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
             top: 0,
             left: 0,
             right: 0,
-            bottom: isMobile ? 56 : 0, // モバイル: フッターの高さ分空けてタップ可能に
+            bottom: isMobile ? 56 : 0, // モバイル: フッターを視覚的に表示
             backgroundColor: 'rgba(0,0,0,0.9)',
             display: 'flex',
             alignItems: 'center',


### PR DESCRIPTION
## Summary
- フッターナビゲーションタップ時に全モーダルをクリア:
  - `setSelectedRecord(null)` - 詳細モーダル
  - `setEditingRecord(null)` - 編集モーダル
  - `setDeletingRecord(null)` - 削除確認モーダル
- コメントを正確に修正（「タップ可能に」→「視覚的に表示」）

## 根本原因分析

**問題**: フッターをタップしても画面遷移しない

**調査過程**:
1. z-index問題と仮定 → 複数のPRで修正を試みたが解決せず
2. DevToolsの要素選択ツールでフッターボタンを選択 → **正しく選択された**
3. つまりボタンは最前面にあり、クリックイベントは発火している

**真の原因**:
```
onItemClick → setActiveTab(id) のみ
           → selectedRecord, editingRecord, deletingRecord がクリアされない
           → モーダルが表示され続ける
           → 画面遷移しないように見える
```

**学び**:
- z-index/スタッキングコンテキスト問題ではなく、状態管理の問題だった
- DevToolsの要素選択ツールで最前面要素を確認することで、z-index問題かどうか切り分け可能

## 過去のPR評価

| PR | 内容 | 評価 |
|---|---|---|
| #354 | z-index 30→100 | 維持（モーダル内ボタン用） |
| #355-358 | bottom: 56px | 維持（UX向上：フッター可視化） |
| #357 | Portal | 維持（モーダルの標準実装） |

## Test plan
- [x] テスト通過
- [ ] 詳細モーダル表示中→フッタータップ→モーダル閉じて遷移
- [ ] 編集モーダル表示中→フッタータップ→モーダル閉じて遷移
- [ ] 削除確認モーダル表示中→フッタータップ→モーダル閉じて遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)