### PR TITLE
feat(animation): 保存成功時のハートアニメーションを実装

### DIFF
--- a/src/components/FishingRecordForm.tsx
+++ b/src/components/FishingRecordForm.tsx
@@ -5,6 +5,7 @@ import { useValidatedForm } from '../hooks/useFormValidation';
 import { createFishingRecordSchema, type CreateFishingRecordFormData } from '../lib/validation';
 import { PhotoUpload } from './PhotoUpload';
 import { FishSpeciesAutocomplete } from './FishSpeciesAutocomplete';
+import { HeartAnimation } from './animation/HeartAnimation';
 import { photoService } from '../lib/photo-service';
 import type { PhotoMetadata, AutoFillData, FishSpecies } from '../types';
 import type { TideInfo } from '../types/tide';
@@ -51,6 +52,7 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
   const [extractedMetadata, setExtractedMetadata] = useState<PhotoMetadata | null>(null);
   const [tideInfo, setTideInfo] = useState<TideInfo | null>(null);
   const [tideLoading, setTideLoading] = useState(false);
+  const [showHeartAnimation, setShowHeartAnimation] = useState(false);
 
   const {
     register,
@@ -223,6 +225,9 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
       }
 
       await onSubmit(submissionData);
+
+      // 保存成功時にハートアニメーションを表示
+      setShowHeartAnimation(true);
     });
   };
 
@@ -1486,6 +1491,12 @@ export const FishingRecordForm: React.FC<FishingRecordFormProps> = ({
           }
         }
       `}</style>
+
+      {/* 保存成功時のハートアニメーション */}
+      <HeartAnimation
+        visible={showHeartAnimation}
+        onAnimationEnd={() => setShowHeartAnimation(false)}
+      />
     </div>
   );
 };

--- a/src/components/__tests__/HeartAnimation.test.tsx
+++ b/src/components/__tests__/HeartAnimation.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * HeartAnimationコンポーネントの単体テスト
+ *
+ * @description
+ * 保存成功時のハートアニメーションコンポーネントのテストスイート
+ *
+ * @version 1.0.0
+ * @since 2025-12-03 Issue #324
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { HeartAnimation } from '../animation/HeartAnimation';
+
+describe('HeartAnimation', () => {
+  beforeEach(async () => {
+    // CI環境でのJSDOM初期化待機
+    if (process.env.CI) {
+      await waitFor(
+        () => {
+          if (!document.body || document.body.children.length === 0) {
+            throw new Error('JSDOM not ready');
+          }
+        },
+        { timeout: 5000, interval: 100 }
+      );
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  });
+
+  afterEach(() => {
+    // CI環境ではroot containerを保持
+    if (!process.env.CI) {
+      document.body.innerHTML = '';
+    }
+  });
+
+  describe('表示制御', () => {
+    it('visible=falseの場合は何もレンダリングしない', () => {
+      const { container } = render(<HeartAnimation visible={false} />);
+      expect(container.querySelector('.heart-animation-container')).toBeNull();
+    });
+
+    it('visible=trueの場合はハートアニメーションがレンダリングされる', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const heartContainer = container.querySelector('.heart-animation-container');
+      expect(heartContainer).toBeInTheDocument();
+    });
+
+    it('ハートアイコン（SVG）がレンダリングされる', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveClass('heart-animation');
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('role="status"とaria-live="polite"を持つスクリーンリーダー用要素がある', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const srOnly = container.querySelector('.sr-only');
+      expect(srOnly).toBeInTheDocument();
+      expect(srOnly).toHaveAttribute('role', 'status');
+      expect(srOnly).toHaveAttribute('aria-live', 'polite');
+      expect(srOnly).toHaveTextContent('保存が完了しました');
+    });
+
+    it('ハートアニメーションコンテナはaria-hidden="true"で装飾的である', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const heartContainer = container.querySelector('.heart-animation-container');
+      expect(heartContainer).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('アニメーション終了時のコールバック', () => {
+    it('onAnimationEndコールバックが呼び出される', () => {
+      const handleAnimationEnd = vi.fn();
+      const { container } = render(
+        <HeartAnimation visible={true} onAnimationEnd={handleAnimationEnd} />
+      );
+
+      const heartContainer = container.querySelector('.heart-animation-container');
+      expect(heartContainer).toBeInTheDocument();
+
+      // animationendイベントを発火
+      fireEvent.animationEnd(heartContainer!);
+
+      expect(handleAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('onAnimationEndが提供されていない場合でもエラーが発生しない', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+
+      const heartContainer = container.querySelector('.heart-animation-container');
+      expect(heartContainer).toBeInTheDocument();
+
+      // animationendイベントを発火（エラーが発生しないことを確認）
+      expect(() => {
+        fireEvent.animationEnd(heartContainer!);
+      }).not.toThrow();
+    });
+  });
+
+  describe('複数回の表示', () => {
+    it('visibleがfalse→trueに変わると再度アニメーションが開始される', () => {
+      const { container, rerender } = render(<HeartAnimation visible={false} />);
+
+      expect(container.querySelector('.heart-animation-container')).toBeNull();
+
+      // visible=trueに変更
+      rerender(<HeartAnimation visible={true} />);
+      expect(container.querySelector('.heart-animation-container')).toBeInTheDocument();
+    });
+
+    it('連続してvisibleを切り替えても正しく動作する', () => {
+      const handleAnimationEnd = vi.fn();
+      const { container, rerender } = render(
+        <HeartAnimation visible={true} onAnimationEnd={handleAnimationEnd} />
+      );
+
+      // アニメーション終了をシミュレート
+      const heartContainer = container.querySelector('.heart-animation-container');
+      fireEvent.animationEnd(heartContainer!);
+      expect(handleAnimationEnd).toHaveBeenCalledTimes(1);
+
+      // 非表示→再表示
+      rerender(<HeartAnimation visible={false} onAnimationEnd={handleAnimationEnd} />);
+      rerender(<HeartAnimation visible={true} onAnimationEnd={handleAnimationEnd} />);
+
+      const newHeartContainer = container.querySelector('.heart-animation-container');
+      expect(newHeartContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('スタイリング', () => {
+    it('heart-animationクラスが適用されている', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveClass('heart-animation');
+    });
+
+    it('ハートのサイズが80pxである', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '80');
+      expect(svg).toHaveAttribute('height', '80');
+    });
+
+    it('heart-animation-containerクラスが適用されている', () => {
+      const { container } = render(<HeartAnimation visible={true} />);
+      const heartContainer = container.querySelector('.heart-animation-container');
+      expect(heartContainer).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/animation/HeartAnimation.tsx
+++ b/src/components/animation/HeartAnimation.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { Heart } from 'lucide-react';
+
+interface HeartAnimationProps {
+  visible: boolean;
+  onAnimationEnd?: () => void;
+}
+
+export const HeartAnimation: React.FC<HeartAnimationProps> = ({
+  visible,
+  onAnimationEnd,
+}) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setIsAnimating(true);
+    }
+  }, [visible]);
+
+  const handleAnimationEnd = () => {
+    setIsAnimating(false);
+    onAnimationEnd?.();
+  };
+
+  if (!visible && !isAnimating) return null;
+
+  return (
+    <>
+      {/* スクリーンリーダー向けの明示的な通知 */}
+      <div role="status" aria-live="polite" className="sr-only">
+        保存が完了しました
+      </div>
+      <div
+        className="heart-animation-container"
+        onAnimationEnd={handleAnimationEnd}
+        aria-hidden="true"
+      >
+        <Heart
+          size={80}
+          className="heart-animation"
+        />
+      </div>
+    </>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -175,6 +175,9 @@ input, textarea, select {
   /* Accent text */
   --color-accent-text: #60a5fa;
 
+  /* Heart Animation */
+  --color-heart-animation: #ef4444;
+
   /* === Glass Morphism System === */
   /* Base variables (theme-independent) */
   --glass-blur: blur(10px) saturate(150%);
@@ -260,6 +263,9 @@ body.light-theme {
 
   /* Accent text */
   --color-accent-text: #3b82f6;
+
+  /* Heart Animation - Light Theme (slightly darker for contrast) */
+  --color-heart-animation: #dc2626;
 
   /* Glass Morphism - Light Theme - Fully transparent */
   --glass-bg: transparent;
@@ -599,4 +605,72 @@ body.low-performance:not(.light-theme) .glass-panel-glass {
 body.low-performance .glass-badge-shadow,
 body.low-performance .glass-panel-shadow {
   display: none;
+}
+
+/* === Screen Reader Only === */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* === Heart Animation === */
+.heart-animation-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.heart-animation {
+  animation: heartBeat 1.5s var(--transition-bounce) forwards;
+  fill: var(--color-heart-animation);
+  stroke: var(--color-heart-animation);
+}
+
+@keyframes heartBeat {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  20% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  46% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+}
+
+/* prefers-reduced-motion: アニメーション軽減 */
+@media (prefers-reduced-motion: reduce) {
+  .heart-animation {
+    animation: none;
+    opacity: 1;
+    transform: scale(1);
+  }
+  .heart-animation-container {
+    animation: fadeInOut 1.5s ease forwards;
+  }
+  @keyframes fadeInOut {
+    0%, 100% {
+      opacity: 0;
+    }
+    20%, 80% {
+      opacity: 1;
+    }
+  }
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -38,6 +38,7 @@ export default defineWorkspace([
         'src/components/__tests__/PhotoHeroCard.test.tsx', // Issue #319: PhotoHeroCard
         'src/components/__tests__/RecordGrid.test.tsx', // Issue #320: RecordGrid
         'src/components/__tests__/FishIcon.test.tsx', // Issue #321: FishIcon
+        'src/components/__tests__/HeartAnimation.test.tsx', // Issue #324: HeartAnimation
       ],
       setupFiles: ['./src/setupTests.ts'],
       environment: 'jsdom',


### PR DESCRIPTION
## Summary
- 新規記録保存成功時に画面中央にハートアニメーションを表示
- ダーク/ライトテーマ対応（CSS変数で色管理）
- アクセシビリティ対応（aria-live, prefers-reduced-motion）

## 変更内容
- `src/components/animation/HeartAnimation.tsx` - 新規作成
- `src/components/__tests__/HeartAnimation.test.tsx` - テスト追加（12ケース）
- `src/components/FishingRecordForm.tsx` - 統合
- `src/index.css` - アニメーションCSS追加
- `vitest.workspace.ts` - テスト設定追加

## Test plan
- [x] `npm run test:fast -- HeartAnimation` - 12/12パス
- [x] `npm run typecheck` - エラーなし
- [x] `npm run build` - 成功
- [ ] 手動確認: 新規記録保存時にハートアニメーションが表示される
- [ ] 手動確認: ダーク/ライトテーマで適切な色が表示される

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)