### PR TITLE
fix(ios): iOS Safariでの「1回目hover、2回目click」問題を修正

### DIFF
--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -42,16 +42,6 @@ const NavItem: React.FC<{
       }}
       onClick={() => onItemClick(item.id)}
       onPointerDown={(e) => createRipple(e as unknown as React.MouseEvent<HTMLButtonElement>)}
-      onMouseEnter={(e) => {
-        if (!item.active) {
-          e.currentTarget.style.backgroundColor = 'var(--color-surface-hover)';
-        }
-      }}
-      onMouseLeave={(e) => {
-        if (!item.active) {
-          e.currentTarget.style.backgroundColor = 'transparent';
-        }
-      }}
       aria-label={item.label}
       aria-selected={item.active}
       aria-current={item.active ? 'page' : undefined}

--- a/src/components/record/PhotoHeroCard.css
+++ b/src/components/record/PhotoHeroCard.css
@@ -288,8 +288,10 @@ body.light-theme .photo-hero-card--fit-contain .photo-hero-card__photo-backgroun
   min-width: var(--touch-target-min);
 }
 
-.photo-hero-card__retry-button:hover {
-  background: var(--color-surface-hover);
+@media (hover: hover) and (pointer: fine) {
+  .photo-hero-card__retry-button:hover {
+    background: var(--color-surface-hover);
+  }
 }
 
 .photo-hero-card__retry-button:disabled {
@@ -583,7 +585,19 @@ body.light-theme .photo-hero-card--fit-contain .photo-hero-card__photo-backgroun
   transition: opacity 0.2s ease;
 }
 
-.photo-hero-card:hover .photo-hero-card__map-bar,
+/* ホバーエフェクトはマウス/トラックパッドデバイスのみ */
+/* iOS Safari で「1回目hover、2回目click」問題を回避 */
+@media (hover: hover) and (pointer: fine) {
+  .photo-hero-card:hover .photo-hero-card__map-bar {
+    opacity: 1;
+  }
+
+  .photo-hero-card:hover .photo-hero-card__map-bar svg {
+    transform: scale(1.15);
+  }
+}
+
+/* フォーカス表示は全デバイスで有効 */
 .photo-hero-card:focus-visible .photo-hero-card__map-bar {
   opacity: 1;
 }
@@ -592,7 +606,6 @@ body.light-theme .photo-hero-card--fit-contain .photo-hero-card__photo-backgroun
   transition: transform 0.2s ease;
 }
 
-.photo-hero-card:hover .photo-hero-card__map-bar svg,
 .photo-hero-card:focus-visible .photo-hero-card__map-bar svg {
   transform: scale(1.15);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,16 @@ button {
   background: none;
   cursor: pointer;
   outline: none;
+  /* iOS Safari: ダブルタップズーム防止でタップ反応性向上 */
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* === タッチデバイス向けグローバル設定 === */
+/* iOS Safari での「1回目hover、2回目click」問題を回避 */
+a, button, [role="button"], [role="tab"], .photo-hero-card, .card-hover-effect {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* フォーカス管理 */
@@ -465,10 +475,13 @@ input[type="search"]::-webkit-search-results-decoration {
   justify-content: center;
 }
 
-.glass-badge-wrapper--interactive:hover .glass-badge-glass {
-  will-change: transform; /* Apply only on hover for performance */
-  transform: translateY(-1px) translateZ(0);
-  box-shadow: 0 12px 40px rgba(31, 38, 135, 0.2);
+/* ホバーエフェクトはマウス/トラックパッドデバイスのみ */
+@media (hover: hover) and (pointer: fine) {
+  .glass-badge-wrapper--interactive:hover .glass-badge-glass {
+    will-change: transform; /* Apply only on hover for performance */
+    transform: translateY(-1px) translateZ(0);
+    box-shadow: 0 12px 40px rgba(31, 38, 135, 0.2);
+  }
 }
 
 .glass-badge-wrapper--interactive:active .glass-badge-glass {
@@ -704,14 +717,18 @@ body.low-performance .glass-panel-shadow {
               box-shadow var(--transition-smooth);
 }
 
-.card-hover-effect:hover {
-  transform: translateY(-4px) translateZ(0);
-  box-shadow: 0 12px 48px rgba(31, 38, 135, 0.2);
-}
+/* ホバーエフェクトはマウス/トラックパッドデバイスのみ */
+/* iOS Safari で「1回目hover、2回目click」問題を回避 */
+@media (hover: hover) and (pointer: fine) {
+  .card-hover-effect:hover {
+    transform: translateY(-4px) translateZ(0);
+    box-shadow: 0 12px 48px rgba(31, 38, 135, 0.2);
+  }
 
-.card-hover-effect:hover .glass-badge-glass {
-  transform: scale(1.05) translateZ(0);
-  transition: transform var(--transition-smooth);
+  .card-hover-effect:hover .glass-badge-glass {
+    transform: scale(1.05) translateZ(0);
+    transition: transform var(--transition-smooth);
+  }
 }
 
 /* prefers-reduced-motion */


### PR DESCRIPTION
## Summary
- iOS Safariでの「複数回タップが必要」問題の根本原因を特定・修正
- `:hover`スタイルをタッチデバイスで無効化し、1回のタップでclickが発火するように

## 根本原因
iOS Safariでは、`:hover`スタイルが設定された要素をタップすると：
1. **1回目のタップ**: `:hover`状態になる（clickは発火しない）
2. **2回目のタップ**: 実際のclickイベントが発火

これが「ホーム画面から別タブをクリックしても反応しづらい」「複数回タップが必要」の原因でした。

## 修正内容
| ファイル | 修正 |
|----------|------|
| `src/index.css` | `touch-action: manipulation`をグローバルに追加、`:hover`を`@media (hover: hover) and (pointer: fine)`でラップ |
| `src/components/navigation/BottomNavigation.tsx` | `onMouseEnter`/`onMouseLeave`を削除 |
| `src/components/record/PhotoHeroCard.css` | `:hover`を`@media (hover: hover)`でラップ |

## なぜ先の修正（#367 useRipple）が効かなかったか
リップル効果の非同期DOM操作は問題ではなく、**CSS :hoverによるタップの2段階発火**が真の原因だった。

## Test plan
- [ ] iPhoneのSafariでホーム画面から別タブを1回タップで切り替えられることを確認
- [ ] iPhoneのSafariで最近の記録から写真詳細を1回タップで開けることを確認
- [ ] iPhoneのSafariで詳細画面の戻るボタンが1回タップで反応することを確認
- [ ] PC（Chrome/Safari）でホバーエフェクトが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)