### PR TITLE
fix(ios): FloatingActionButtonのiOS Safariタップ問題を修正

### DIFF
--- a/src/components/ui/FloatingActionButton.tsx
+++ b/src/components/ui/FloatingActionButton.tsx
@@ -105,18 +105,13 @@ const FloatingActionButton = forwardRef<HTMLButtonElement, FloatingActionButtonP
     />
   );
 
-  // Handle mouse/pointer events for press feedback
-  const [isPressed, setIsPressed] = React.useState(false);
-
-  const handleMouseDown = () => setIsPressed(true);
-  const handleMouseUp = () => setIsPressed(false);
-
   // Combine all styles
+  // Note: Press feedback is handled via CSS :active pseudo-class (fab-active)
+  // to avoid iOS Safari tap detection issues with JavaScript state management
   const combinedStyles: React.CSSProperties = {
     ...baseStyles,
     ...sizeStyles[size],
     ...variantStyles[variant],
-    ...(isPressed && !disabled && !loading ? { transform: 'scale(0.95)' } : {}),
   };
 
   // Combine class names
@@ -136,11 +131,9 @@ const FloatingActionButton = forwardRef<HTMLButtonElement, FloatingActionButtonP
 
       <button
         ref={ref}
-        className={combinedClassName}
+        className={`${combinedClassName} fab-active`}
         style={combinedStyles}
         disabled={disabled || loading}
-        onPointerDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
         data-testid={(props as any)["data-testid"] || "floating-action-button"}
         {...props}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -867,6 +867,19 @@ body.low-performance .glass-panel-shadow {
   }
 }
 
+/* === FloatingActionButton Press Feedback === */
+/* iOS Safari対応: JavaScriptの状態管理を使わずCSSのみで実装 */
+/* onPointerDown/onMouseUp + isPressed状態だとiOS Safariでタップが効かない問題を回避 */
+.fab-active:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fab-active:active:not(:disabled) {
+    transform: none;
+  }
+}
+
 /* === Screen Reader Only === */
 .sr-only {
   position: absolute;


### PR DESCRIPTION
## Summary
- FloatingActionButtonがiOS Safariでタップに反応しない問題を修正
- `isPressed`状態管理と`onPointerDown`/`onMouseUp`を削除
- CSS `:active`疑似クラスでプレスフィードバックを実装

## 原因分析
iOS Safariのクリック判定:
```
touchstart → pointerdown → touchend → pointerup → mouseup → click
```

従来の実装:
1. `onPointerDown`で`isPressed=true`を設定
2. `isPressed`時に`transform: scale(0.95)`を適用
3. iOS Safariはタップ開始位置と終了位置の要素が異なると`click`イベントを発火しない
4. `transform`による縮小でヒットエリアが変化し、同一要素と判定されなくなっていた

## 修正内容
| ファイル | 変更 |
|----------|------|
| `FloatingActionButton.tsx` | `isPressed`状態、`onPointerDown`/`onMouseUp`削除 |
| `index.css` | `.fab-active:active` スタイル追加 |

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run test:fast` 通過 (79 passed)
- [x] `npm run build` 成功
- [ ] iOS Safari実機でFABタップが1回で反応することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)