### PR TITLE
fix(swipe): iOS Safari対応 - touch-action継承 + キャプチャフェーズ

### DIFF
--- a/src/components/FishingRecordDetail.tsx
+++ b/src/components/FishingRecordDetail.tsx
@@ -121,7 +121,11 @@ export const FishingRecordDetail: React.FC<FishingRecordDetailProps> = ({
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [tideChartData, setTideChartData] = useState<TideChartData[] | null>(null);
   const [tideLoading, setTideLoading] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  // isMobileを即座に計算（不要な再レンダリングを防ぐ）
+  // SSRではwindowが存在しないためfalseを使用
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  );
   const [photoFitMode, setPhotoFitMode] = useState<'cover' | 'contain'>('cover');
   const [localPhotoUrl, setLocalPhotoUrl] = useState<string | null>(null);
   // 2ステップ共有用の状態

--- a/src/components/record/PhotoHeroCard.css
+++ b/src/components/record/PhotoHeroCard.css
@@ -84,6 +84,21 @@
   transform: none !important;
   box-shadow: none !important;
   cursor: default;
+  /*
+   * iOS Safari スワイプ対応:
+   * CSS touch-actionは継承されないため、明示的に設定する必要がある。
+   * これがないとpreventDefault()が効かず、スワイプが動作しない。
+   */
+  touch-action: none !important;
+}
+
+/* iOS Safari: touch-actionは継承されないため、すべての子要素にも設定 */
+.photo-hero-card--fullscreen *,
+.photo-hero-card--fullscreen .photo-hero-card__photo-container,
+.photo-hero-card--fullscreen .photo-hero-card__photo-background,
+.photo-hero-card--fullscreen .photo-hero-card__photo-foreground,
+.photo-hero-card--fullscreen img {
+  touch-action: none !important;
 }
 
 .photo-hero-card--fullscreen:hover {

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -642,29 +642,33 @@ export function useSwipe<T extends HTMLElement = HTMLElement>(
 
     if (supportsPointerEvents) {
       // PointerEventを使用（モダンブラウザ）
-      element.addEventListener('pointerdown', handlePointerDown as EventListener);
-      element.addEventListener('pointermove', handlePointerMove as EventListener, { passive: false });
-      element.addEventListener('pointerup', handlePointerUp as EventListener);
-      element.addEventListener('pointercancel', handlePointerCancel as EventListener);
+      // キャプチャフェーズで登録（子要素より先に処理される）
+      // これにより、子要素のイベントハンドラがstopPropagation()しても影響を受けない
+      element.addEventListener('pointerdown', handlePointerDown as EventListener, { capture: true });
+      element.addEventListener('pointermove', handlePointerMove as EventListener, { capture: true, passive: false });
+      element.addEventListener('pointerup', handlePointerUp as EventListener, { capture: true });
+      element.addEventListener('pointercancel', handlePointerCancel as EventListener, { capture: true });
     } else {
       // TouchEventにフォールバック（古いブラウザ）
-      element.addEventListener('touchstart', handlePointerDown as EventListener);
-      element.addEventListener('touchmove', handlePointerMove as EventListener, { passive: false });
-      element.addEventListener('touchend', handlePointerUp as EventListener);
-      element.addEventListener('touchcancel', handlePointerCancel as EventListener);
+      // 同様にキャプチャフェーズで登録
+      element.addEventListener('touchstart', handlePointerDown as EventListener, { capture: true });
+      element.addEventListener('touchmove', handlePointerMove as EventListener, { capture: true, passive: false });
+      element.addEventListener('touchend', handlePointerUp as EventListener, { capture: true });
+      element.addEventListener('touchcancel', handlePointerCancel as EventListener, { capture: true });
     }
 
     return () => {
       if (supportsPointerEvents) {
-        element.removeEventListener('pointerdown', handlePointerDown as EventListener);
-        element.removeEventListener('pointermove', handlePointerMove as EventListener);
-        element.removeEventListener('pointerup', handlePointerUp as EventListener);
-        element.removeEventListener('pointercancel', handlePointerCancel as EventListener);
+        // キャプチャフェーズで登録したリスナーを削除（captureオプション必須）
+        element.removeEventListener('pointerdown', handlePointerDown as EventListener, { capture: true });
+        element.removeEventListener('pointermove', handlePointerMove as EventListener, { capture: true });
+        element.removeEventListener('pointerup', handlePointerUp as EventListener, { capture: true });
+        element.removeEventListener('pointercancel', handlePointerCancel as EventListener, { capture: true });
       } else {
-        element.removeEventListener('touchstart', handlePointerDown as EventListener);
-        element.removeEventListener('touchmove', handlePointerMove as EventListener);
-        element.removeEventListener('touchend', handlePointerUp as EventListener);
-        element.removeEventListener('touchcancel', handlePointerCancel as EventListener);
+        element.removeEventListener('touchstart', handlePointerDown as EventListener, { capture: true });
+        element.removeEventListener('touchmove', handlePointerMove as EventListener, { capture: true });
+        element.removeEventListener('touchend', handlePointerUp as EventListener, { capture: true });
+        element.removeEventListener('touchcancel', handlePointerCancel as EventListener, { capture: true });
       }
     };
   }, [element, onPointerDown, onPointerMove, onPointerUp, onPointerCancel]);


### PR DESCRIPTION
## Summary
iOS Safariでスワイプナビゲーションが動作しない問題を修正

## Root Cause Analysis（テックリード分析）

### 🔴 問題1: CSS touch-actionは継承されない
```
親要素に touch-action: none を設定しても、子要素には継承されない
→ PhotoHeroCard内の画像やパネルでpreventDefault()が効かない
→ ブラウザのデフォルトスクロール動作が発動
```

### 🔴 問題2: イベントリスナーがバブリングフェーズで登録
```
バブリングフェーズ: 子→親の順で処理
→ 子要素がstopPropagation()すると親に届かない
→ スワイプイベントが検出されない

キャプチャフェーズ: 親→子の順で処理
→ 親要素が先にイベントを処理できる
```

### 🟡 問題3: isMobileの初期化タイミング
```typescript
// 変更前: 常にfalseで開始→useEffectでtrueに
const [isMobile, setIsMobile] = useState(false);

// 変更後: 即座に正しい値で初期化
const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
```

## Changes

### 1. PhotoHeroCard.css
```css
/* Fullscreen variant全体と子要素にtouch-action追加 */
.photo-hero-card--fullscreen {
  touch-action: none !important;
}

/* CSSは継承されないため、すべての子要素にも設定 */
.photo-hero-card--fullscreen *,
.photo-hero-card--fullscreen img {
  touch-action: none !important;
}
```

### 2. useSwipe.ts
```typescript
// キャプチャフェーズで登録（子要素より先に処理）
element.addEventListener('pointerdown', handler, { capture: true });
element.addEventListener('pointermove', handler, { capture: true, passive: false });
element.addEventListener('pointerup', handler, { capture: true });
```

### 3. FishingRecordDetail.tsx
```typescript
// isMobile初期値を即座に計算
const [isMobile, setIsMobile] = useState(() =>
  typeof window !== 'undefined' ? window.innerWidth <= 768 : false
);
```

## Test plan
- [x] useSwipe unit tests pass
- [x] TypeScript型チェックpass
- [ ] iPhone実機でスワイプ動作確認：
  1. 釣果一覧→任意の釣果カードをタップ→詳細画面
  2. 左右にスワイプ→前後の釣果に遷移

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)